### PR TITLE
fsl/robust_fov

### DIFF
--- a/descriptors/fsl/robust_fov.json
+++ b/descriptors/fsl/robust_fov.json
@@ -1,17 +1,9 @@
 {
   "name": "RobustFOV",
-  "command-line": "RobustFOV [IN_FILE] [ARGS] [BRAINSIZE] [ENVIRON] [OUT_ROI] [OUT_TRANSFORM] [OUTPUT_TYPE]",
+  "command-line": "robustfov [IN_FILE] [BRAINSIZE] [OUT_ROI]",
   "author": "Nipype (interface)",
   "description": "RobustFOV, as implemented in Nipype (module: nipype.interfaces.fsl.utils, interface: RobustFOV).\nAutomatically crops an image removing lower head and neck.\nInterface is stable 5.0.0 to 5.0.9, but default brainsize changed from 150mm to 170mm.",
   "inputs": [
-    {
-      "id": "args",
-      "name": "Args",
-      "type": "String",
-      "value-key": "[ARGS]",
-      "description": "A string. Additional parameters to the command.",
-      "optional": true
-    },
     {
       "id": "brainsize",
       "name": "Brainsize",
@@ -23,15 +15,6 @@
       "optional": true
     },
     {
-      "id": "environ",
-      "name": "Environ",
-      "type": "String",
-      "value-key": "[ENVIRON]",
-      "description": "A dictionary with keys which are a bytes or none or a value of class 'str' and with values which are a bytes or none or a value of class 'str'. Environment variables.",
-      "optional": true,
-      "default-value": {}
-    },
-    {
       "id": "in_file",
       "name": "In file",
       "type": "File",
@@ -39,49 +22,17 @@
       "command-line-flag": "-i",
       "description": "A pathlike object or string representing an existing file. Input filename.",
       "optional": false
-    },
-    {
-      "id": "output_type",
-      "name": "Output type",
-      "type": "String",
-      "value-key": "[OUTPUT_TYPE]",
-      "description": "'nifti' or 'nifti_pair' or 'nifti_gz' or 'nifti_pair_gz'. Fsl output type.",
-      "optional": true,
-      "value-choices": ["NIFTI", "NIFTI_PAIR", "NIFTI_GZ", "NIFTI_PAIR_GZ"]
     }
   ],
   "output-files": [
     {
-      "name": "Out roi",
+      "name": "Out_roi",
       "id": "out_roi",
       "optional": true,
       "description": "A pathlike object or string representing a file. Roi volume output name.",
       "path-template": "[IN_FILE]_ROI",
       "value-key": "[OUT_ROI]",
       "command-line-flag": "-r"
-    },
-    {
-      "name": "Out transform",
-      "id": "out_transform",
-      "optional": true,
-      "description": "A pathlike object or string representing a file. Transformation matrix in_file to out_roi output name.",
-      "path-template": "[IN_FILE]_to_ROI",
-      "value-key": "[OUT_TRANSFORM]",
-      "command-line-flag": "-m"
-    },
-    {
-      "name": "Out roi",
-      "id": "out_roi",
-      "path-template": "out_roi",
-      "optional": true,
-      "description": "A pathlike object or string representing an existing file. Roi volume output name."
-    },
-    {
-      "name": "Out transform",
-      "id": "out_transform",
-      "path-template": "out_transform",
-      "optional": true,
-      "description": "A pathlike object or string representing an existing file. Transformation matrix in_file to out_roi output name."
     }
   ],
   "tool-version": "1.0.0",


### PR DESCRIPTION
***************************************************
The following COMPULSORY options :
        -i      input filename
***************************************************

Part of FSL (ID: "")
robustfov 
Copyright(c) 2012, University of Oxford (Mark Jenkinson)

Reduce FOV of image to remove lower head and neck.

Usage: 
robustfov [options] -i <image> -r <outputimage>
robustfov [options] -i <image>

Compulsory arguments (You MUST set one or more of):
        -i      input filename

Optional arguments (You may optionally specify one or more of):
        -b      size of brain in z-dimension (default 170mm)
        -m      matrix output name (roi to full fov)
        -r      ROI volume output name
        --debug turn on debugging output
        -v,--verbose    switch on diagnostic messages
        -h,--help       display this message