### PR TITLE
Update docker images

### DIFF
--- a/descriptors/ants/ants_registration_syn_sh.json
+++ b/descriptors/ants/ants_registration_syn_sh.json
@@ -1,14 +1,14 @@
 {
   "name": "antsRegistrationSyN",
   "command-line": "antsRegistrationSyN.sh [IMAGE_DIMENSION] [FIXED_IMAGE] [MOVING_IMAGE] [OUTPUT_PREFIX] [THREADS] [INITIAL_TRANSFORM] [TRANSFORM_TYPE] [RADIUS] [SPLINE_DISTANCE] [GRADIENT_STEP] [MASKS] [PRECISION_TYPE] [USE_HISTOGRAM_MATCHING] [USE_REPRO_MODE] [COLLAPSE_OUTPUT_TRANSFORMS] [RANDOM_SEED]",
-  "description": "This script performs image registration using the SyN transform from the ANTs suite. The user can specify the dimensionality of the images, the fixed and moving images, and the output prefix. It supports various types of transformations and optional parameters such as initial transforms, gradient step size, mask usage, and more.",
   "author": "Brian B. Avants, Nick Tustison, and Gang Song",
+  "description": "This script performs image registration using the SyN transform from the ANTs suite. The user can specify the dimensionality of the images, the fixed and moving images, and the output prefix. It supports various types of transformations and optional parameters such as initial transforms, gradient step size, mask usage, and more.",
   "url": "https://github.com/ANTsX/ANTs/",
-  "tool-version": "latest",
+  "tool-version": "2.5.3",
   "schema-version": "0.5",
   "container-image": {
     "type": "docker",
-    "image": "fcpindi/c-pac:latest"
+    "image": "antsx/ants:v2.5.3"
   },
   "inputs": [
     {

--- a/descriptors/ants/atropos.json
+++ b/descriptors/ants/atropos.json
@@ -1,14 +1,14 @@
 {
   "name": "Atropos",
   "command-line": "Atropos [IMAGE_DIMENSIONALITY] [INTENSITY_IMAGE] [BSPLINE] [INITIALIZATION] [PARTIAL_VOLUME_LABEL_SET] [USE_PARTIAL_VOLUME_LIKELIHOODS] [POSTERIOR_FORMULATION] [MASK_IMAGE] [CONVERGENCE] [LIKELIHOOD_MODEL] [MRF] [ICM] [USE_RANDOM_SEED] [OUTPUT] [MINIMIZE_MEMORY_USAGE] [WINSORIZE_OUTLIERS] [USE_EUCLIDEAN_DISTANCE] [LABEL_PROPAGATION] [VERBOSE]",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
   "description": "A finite mixture modeling (FMM) segmentation approach with possibilities for specifying prior constraints. These prior constraints include the specification of a prior label image, prior probability images (one for each class), and/or an MRF prior to enforce spatial smoothing of the labels. All segmentation images including priors and masks must be in the same voxel and physical space. Similar algorithms include FAST and SPM.",
-  "author": "ANTs authors",
   "url": "https://github.com/ANTsX/ANTs",
-  "tool-version": "latest",
+  "tool-version": "2.5.3",
   "schema-version": "0.5",
   "container-image": {
     "type": "docker",
-    "image": "fcpindi/c-pac:latest"
+    "image": "antsx/ants:v2.5.3"
   },
   "inputs": [
     {

--- a/descriptors/ants/atropos_n4.json
+++ b/descriptors/ants/atropos_n4.json
@@ -1,13 +1,13 @@
 {
   "name": "antsAtroposN4.sh",
   "command-line": "antsAtroposN4.sh [IMAGE_DIMENSION] [INPUT_IMAGE] [MASK_IMAGE] [NUMBER_OF_CLASSES] [OUTPUT_PREFIX] [MAX_N4_ATROPOS_ITERATIONS] [MAX_ATROPOS_ITERATIONS] [SEGMENTATION_PRIORS] [MRF] [DENOISE_ANATOMICAL_IMAGES] [POSTERIOR_FORMULATION] [LABEL_PROPAGATION] [POSTERIOR_LABEL_FOR_N4_WEIGHT_MASK] [IMAGE_FILE_SUFFIX] [KEEP_TEMPORARY_FILES] [USE_RANDOM_SEEDING] [ATROPOS_SEGMENTATION_PRIOR_WEIGHT] [N4_CONVERGENCE] [N4_SHRINK_FACTOR] [N4_BSPLINE_PARAMS] [ATROPOS_SEGMENTATION_ICM] [ATROPOS_SEGMENTATION_USE_EUCLIDEAN_DISTANCE] [TEST_DEBUG_MODE]",
-  "author": "ANTs Developers",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
   "description": "Iterates between N4 <-> Atropos to improve segmentation results.",
-  "tool-version": "1.0.0",
+  "tool-version": "2.5.3",
   "schema-version": "0.5",
   "container-image": {
-    "image": "antsx/ants:v2.5.2",
-    "type": "docker"
+    "type": "docker",
+    "image": "antsx/ants:v2.5.3"
   },
   "inputs": [
     {

--- a/descriptors/ants/brain_extraction_sh.json
+++ b/descriptors/ants/brain_extraction_sh.json
@@ -1,12 +1,14 @@
 {
-  "tool-version": "1.0.0",
   "name": "antsBrainExtraction.sh",
+  "command-line": "antsBrainExtraction.sh -d [DIMENSION] -a [ANATOMICAL_IMAGE] -e [BRAIN_EXTRACTION_TEMPLATE] -m [BRAIN_EXTRACTION_PROBABILITY_MASK] [TISSUE_CLASSIFICATION] [BRAIN_EXTRACTION_REGISTRATION_MASK] [KEEP_TEMP] [SINGLE_FLOAT_PRECISION] [INITIAL_MOVING_TRANSFORM] [ROTATION_SEARCH] [IMAGE_SUFFIX] [TRANSLATION_SEARCH] [RANDOM_SEEDING] [DEBUG_MODE] -o [OUTPUT_PREFIX]",
   "author": "Advanced Normalization Tools (ANTs) Contributors",
+  "description": "antsBrainExtraction.sh is a script from Advanced Normalization Tools (ANTs) for template-based brain extraction.",
   "url": "https://github.com/ANTsX/ANTs",
-  "command-line": "export PATH=$PATH:/opt/ants/bin && antsBrainExtraction.sh -d [DIMENSION] -a [ANATOMICAL_IMAGE] -e [BRAIN_EXTRACTION_TEMPLATE] -m [BRAIN_EXTRACTION_PROBABILITY_MASK] [TISSUE_CLASSIFICATION] [BRAIN_EXTRACTION_REGISTRATION_MASK] [KEEP_TEMP] [SINGLE_FLOAT_PRECISION] [INITIAL_MOVING_TRANSFORM] [ROTATION_SEARCH] [IMAGE_SUFFIX] [TRANSLATION_SEARCH] [RANDOM_SEEDING] [DEBUG_MODE] -o [OUTPUT_PREFIX]",
+  "tool-version": "2.5.3",
+  "schema-version": "0.5",
   "container-image": {
-    "image": "antsx/ants",
-    "type": "docker"
+    "type": "docker",
+    "image": "antsx/ants:v2.5.3"
   },
   "inputs": [
     {
@@ -163,8 +165,6 @@
       "path-template": "[OUTPUT_PREFIX]BrainExtractionPrior0GenericAffine.mat"
     }
   ],
-  "schema-version": "0.5",
-  "description": "antsBrainExtraction.sh is a script from Advanced Normalization Tools (ANTs) for template-based brain extraction.",
   "tags": {
     "domain": ["neuroinformatics", "mri", "brain extraction"]
   }

--- a/descriptors/ants/denoise_image.json
+++ b/descriptors/ants/denoise_image.json
@@ -1,10 +1,15 @@
 {
   "name": "DenoiseImage",
   "command-line": "DenoiseImage [IMAGE_DIMENSIONALITY] [NOISE_MODEL] [SHRINK_FACTOR] [MASK_IMAGE] [PATCH_RADIUS] [SEARCH_RADIUS] [VERBOSE] [INPUT_IMAGE]   --output [[CORRECTED_IMAGE],[NOISE_IMAGE]]",
-  "author": "ANTs authors",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
   "description": "Denoise an image using a spatially adaptive filter originally described in J. V.  Manjon, P. Coupe, Luis Marti-Bonmati, D. L. Collins, and M. Robles. Adaptive Non-Local Means Denoising of MR Images With Spatially Varying Noise Levels, Journal of Magnetic Resonance Imaging, 31:192-203, June 2010.",
   "url": "https://github.com/ANTsX/ANTs",
-  "tool-version": "v2.4.3-gcaa60eb",
+  "tool-version": "2.5.3",
+  "schema-version": "0.5",
+  "container-image": {
+    "type": "docker",
+    "image": "antsx/ants:v2.5.3"
+  },
   "inputs": [
     {
       "id": "image_dimensionality",
@@ -117,11 +122,6 @@
       "optional": false
     }
   ],
-  "schema-version": "0.5",
-  "container-image": {
-    "image": "fcpindi/c-pac:latest",
-    "type": "docker"
-  },
   "tags": {
     "domain": "neuroinformatics"
   }

--- a/descriptors/ants/multiply_images.json
+++ b/descriptors/ants/multiply_images.json
@@ -1,8 +1,15 @@
 {
   "name": "MultiplyImages",
   "command-line": "MultiplyImages [DIMENSION] [FIRST_INPUT] [SECOND_INPUT] [OUTPUT_PRODUCT_IMAGE] [NUM_THREADS]",
-  "author": "Nipype (interface)",
-  "description": "No description provided.",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
+  "description": "Multiply 2 images; 2nd image file may also be floating point numerical value, and program will act accordingly -- i.e. read as a number. Program handles vector and tensor images as well",
+  "url": "https://github.com/ANTsX/ANTs",
+  "tool-version": "2.5.3",
+  "schema-version": "0.5",
+  "container-image": {
+    "type": "docker",
+    "image": "antsx/ants:v2.5.3"
+  },
   "inputs": [
     {
       "id": "dimension",
@@ -73,15 +80,5 @@
       "members": ["second_input", "second_input_2"],
       "mutually-exclusive": true
     }
-  ],
-  "tool-version": "1.0.0",
-  "schema-version": "0.5",
-  "container-image": {
-    "image": "fcpindi/c-pac:latest",
-    "type": "docker"
-  },
-  "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
-  }
+  ]
 }

--- a/descriptors/ants/n4_bias_field_correction.json
+++ b/descriptors/ants/n4_bias_field_correction.json
@@ -1,10 +1,15 @@
 {
   "name": "N4BiasFieldCorrection",
   "command-line": "N4BiasFieldCorrection [IMAGE_DIMENSIONALITY] [SHRINK_FACTOR] [MASK_IMAGE] [RESCALE_INTENSITIES] [WEIGHT_IMAGE] [CONVERGENCE] [BSPLINE_FITTING] [HISTOGRAM_SHARPENING] [VERBOSE] [INPUT_IMAGE] --output [[CORRECTED_IMAGE],[BIAS_FIELD]]",
-  "author": "ANTs authors",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
   "description": "N4 is a variant of the popular N3 (nonparameteric nonuniform normalization) retrospective bias correction algorithm. Based on the assumption that the corruption of the low frequency bias field can be modeled as a convolution of the intensity histogram by a Gaussian, the basic algorithmic protocol is to iterate between deconvolving the intensity histogram by a Gaussian, remapping the intensities, and then spatially smoothing this result by a B-spline modeling of the bias field itself. The modifications from and improvements obtained over the original N3 algorithm are described in the following paper: N. Tustison et al., N4ITK: Improved N3 Bias Correction, IEEE Transactions on Medical Imaging, 29(6):1310-1320, June 2010.",
   "url": "https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection",
-  "tool-version": "v2.4.3-gcaa60eb",
+  "tool-version": "2.5.3",
+  "schema-version": "0.5",
+  "container-image": {
+    "type": "docker",
+    "image": "antsx/ants:v2.5.3"
+  },
   "inputs": [
     {
       "id": "image_dimensionality",
@@ -138,11 +143,6 @@
       "optional": false
     }
   ],
-  "schema-version": "0.5",
-  "container-image": {
-    "image": "fcpindi/c-pac:latest",
-    "type": "docker"
-  },
   "tags": {
     "domain": "neuroinformatics"
   }

--- a/descriptors/ants/registration.json
+++ b/descriptors/ants/registration.json
@@ -1,14 +1,14 @@
 {
   "name": "antsRegistration",
   "command-line": "antsRegistration [DIMENSIONALITY] [OUTPUT_TRANSFORM_PREFIX] [SAVE_STATE] [RESTORE_STATE] [WRITE_COMPOSITE_TRANSFORM] [PRINT_SIMILARITY_MEASURE_INTERVAL] [WRITE_INTERVAL_VOLUMES] [COLLAPSE_OUTPUT_TRANSFORMS] [INITIALIZE_TRANSFORMS_PER_STAGE] [INTERPOLATION] [RESTRICT_DEFORMATION] [INITIAL_FIXED_TRANSFORM] [INITIAL_MOVING_TRANSFORM] [STAGES] [WINSORIZE_IMAGE_INTENSITIES] [MASKS] [MINC] [RANDOM_SEED] [VERBOSE]",
+  "author": "Advanced Normalization Tools (ANTs) Contributors",
   "description": "This program is a user-level registration application meant to utilize classes in ITK v4.0 and later. The user can specify any number of \"stages\" where a stage consists of a transform; an image metric; and iterations, shrink factors, and smoothing sigmas for each level. Note that explicitly setting the dimensionality, metric, transform, output, convergence, shrink-factors, and smoothing-sigmas parameters is mandatory.",
-  "author": "ANTs authors",
   "url": "https://github.com/ANTsX/ANTs",
-  "tool-version": "v2.4.3-gcaa60eb",
+  "tool-version": "2.5.3",
   "schema-version": "0.5",
   "container-image": {
     "type": "docker",
-    "image": "fcpindi/c-pac:latest"
+    "image": "antsx/ants:v2.5.3"
   },
   "inputs": [
     {

--- a/descriptors/c3d/c3d.json
+++ b/descriptors/c3d/c3d.json
@@ -1,9 +1,14 @@
 {
   "name": "c3d",
-  "description": "C3D is a command-line tool for medical image processing.",
-  "tool-version": "1.0.0",
-  "schema-version": "0.5",
   "command-line": "c3d [INPUT] [OPERATIONS] [OUTPUT]",
+  "author": "ITK-Snap Team",
+  "description": "C3D is a command-line tool for medical image processing.",
+  "tool-version": "1.1.0",
+  "schema-version": "0.5",
+  "container-image": {
+    "image": "pyushkevich/itksnap:v3.8.2",
+    "type": "docker"
+  },
   "inputs": [
     {
       "id": "input",

--- a/descriptors/c3d/c3d_affine_tool.json
+++ b/descriptors/c3d/c3d_affine_tool.json
@@ -3,6 +3,12 @@
   "command-line": "c3d_affine_tool [REFERENCE_FILE] [SOURCE_FILE] [TRANSFORM_FILE] [SFORM_FILE] [OUT_MATFILE] [FSL2RAS] [RAS2FSL] [INV] [DET] [MULT] [SQRT] [ITK_TRANSFORM] [OUT_ITK_TRANSFORM] [IRTK_TRANSFORM] [OUT_IRTK_TRANSFORM] [INFO] [INFO_FULL]",
   "author": "ITK-Snap Team",
   "description": "RAS affine transform tool",
+  "tool-version": "1.1.0",
+  "schema-version": "0.5",
+  "container-image": {
+    "image": "pyushkevich/itksnap:v3.8.2",
+    "type": "docker"
+  },
   "inputs": [
     {
       "id": "reference_file",
@@ -180,12 +186,6 @@
       "description": "Write output matrix."
     }
   ],
-  "tool-version": "1.0.0",
-  "schema-version": "0.5",
-  "container-image": {
-    "image": "fcpindi/c-pac:latest",
-    "type": "docker"
-  },
   "tags": {
     "domain": "neuroinformatics"
   }

--- a/descriptors/fsl/AnatomicalAverage.json
+++ b/descriptors/fsl/AnatomicalAverage.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "AnatomicalAverage",
   "author": "Brain Imaging Center",
   "descriptor-url": "https://example.com/anatomicalaverage.json",
@@ -7,8 +7,7 @@
   "url": "https://example.com/anatomicalaverage",
   "command-line": "AnatomicalAverage [OPTIONAL_ARGS] -o [OUTPUT_BASENAME] [IMAGES]",
   "container-image": {
-    "image": "brainimagingcenter/anatomicalaverage:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/aff2rigid.json
+++ b/descriptors/fsl/aff2rigid.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "aff2rigid",
   "author": "FMRIB, University of Oxford",
   "description": "Tool for converting affine transformations to rigid transformations.",
   "command-line": "/usr/local/fsl/bin/aff2rigid [INPUT_TRANSFORM] [OUTPUT_TRANSFORM]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/apply_warp.json
+++ b/descriptors/fsl/apply_warp.json
@@ -178,10 +178,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/applytopup.json
+++ b/descriptors/fsl/applytopup.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "applytopup",
   "author": "University of Oxford (Jesper Andersson)",
   "description": "applytopup applies corrections to images using the field estimates produced by topup.",
   "command-line": "applytopup [IMAIN] [DATAIN] [ININDEX] [TOPUP] [OUT] [METHOD] [INTERP] [DATATYPE] [VERBOSE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/applywarp.json
+++ b/descriptors/fsl/applywarp.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/Applywarp",
   "command-line": "applywarp -i [INPUT_FILE] -o [OUTPUT_FILE] -r [REFERENCE_FILE] -w [WARP_COEFF_FILE] --usesqform",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/applyxfm4D.json
+++ b/descriptors/fsl/applyxfm4D.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "applyxfm4D",
   "author": "Unknown",
   "description": "Applies 4D transformation matrices to 4D volumes",
   "command-line": "applyxfm4D [INPUT_VOLUME] [REF_VOLUME] [OUTPUT_VOLUME] [TRANSFORMATION_MATRIX]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/asl_file.json
+++ b/descriptors/fsl/asl_file.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "asl_file",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "ASL data manipulation tool for FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/AslFile",
   "command-line": "asl_file [DATA] [NTIS] [MASK] [IBF] [IAF] [RPTS] [PAIRS] [SPPAIRS] [DIFF] [SURRDIFF] [EXTRAPOLATE] [NEIGHBOUR] [PVGM] [PVWM] [KERNEL] [OUT] [OBF] [MEAN] [SPLIT] [EPOCH] [ELEN] [EOL] [EUNIT] [DECONV] [AIF]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/asl_mfree.json
+++ b/descriptors/fsl/asl_mfree.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "asl_mfree",
   "author": "FMRIB Centre, University of Oxford",
   "description": "ASL model-free analysis tool",
   "command-line": "asl_mfree [DATA] [MASK] [OUT] [AIF] [DT] [METRIC] [MTHRESH] [TCORRECT] [BATA] [BATT] [BAT] [BAT_GRAD_THR] [T1] [FA] [STD] [NWB] [TURBO_QUASAR] [SHIFT_FACTOR] --verbose",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/atlasquery.json
+++ b/descriptors/fsl/atlasquery.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "3.7.0",
+  "tool-version": "6.0.5",
   "name": "atlasquery",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Structural lookup tool for FSL atlases.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlasquery",
   "command-line": "atlasq ohi [DUMPATLASES_FLAG] [ATLAS] [COORD] [MASK] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/avscale.json
+++ b/descriptors/fsl/avscale.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "avscale",
   "author": "Unknown",
   "description": "A command line tool for computing affine transformations.",
   "command-line": "avscale [ALLPARAMS_FLAG] [INVERTED_DDIES_FLAG] [MATRIX_FILE] [NON_REFERENCE_VOLUME] > output.txt",
   "container-image": {
-    "image": "mydockerhubuser/avscale:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/avw2fsl.json
+++ b/descriptors/fsl/avw2fsl.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "avw2fsl",
   "author": "GNU coreutils",
   "descriptor-url": "https://example.com/avw2fsl.json",
@@ -7,8 +7,7 @@
   "url": "http://www.gnu.org/software/coreutils/",
   "command-line": "/bin/cp [OPTIONS] [SOURCE DEST]",
   "container-image": {
-    "image": "gnu/coreutils:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/b0calc.json
+++ b/descriptors/fsl/b0calc.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FUGUE/Guide#fieldmapcreation",
   "command-line": "b0calc -i [INPUT_FILE] -o [OUTPUT_FILE] [ZERO_ORDER_X] [ZERO_ORDER_Y] [ZERO_ORDER_Z] [B0_X] [B0_Y] [B0_Z] [DELTA] [CHI0] [XYZ_FLAG] [EXTEND_BOUNDARY] [DIRECT_CONV] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/basil_var.json
+++ b/descriptors/fsl/basil_var.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "4.0.4",
+  "tool-version": "6.0.5",
   "name": "basil_var",
   "author": "FMRIB Software Library (FSL)",
   "description": "Variance calculator for BASIL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BASIL",
   "command-line": "basil_var -d [RESULTS_DIR] -m [MASK_IMAGE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/baycest.json
+++ b/descriptors/fsl/baycest.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "baycest",
   "author": "Bayesian Analysis Group",
   "description": "Bayesian analysis for chemical exchange saturation transfer z-spectra",
   "command-line": "baycest --data=[DATA_FILE] --mask=[MASK_FILE] --output=[OUTPUT_DIR] --pools=[POOLS_FILE] --spec=[SPEC_FILE] --ptrain=[PTRAIN_FILE] [SPATIAL_FLAG] [T12PRIOR_FLAG]",
   "container-image": {
-    "type": "docker",
-    "image": "baycest/baycest:latest",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/bedpostx.json
+++ b/descriptors/fsl/bedpostx.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bedpostx",
   "author": "FMRIB Centre",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#BEDPOSTX",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#BEDPOSTX",
   "command-line": "bedpostx [SUBJECT_DIR] [NUM_FIBRES] [ARD_WEIGHT] [BURNIN] [NUM_JUMPS] [SAMPLE_EVERY] [MODEL_TYPE] [GRAD_NONLINEAR]",
   "container-image": {
-    "image": "fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bedpostx_datacheck.json
+++ b/descriptors/fsl/bedpostx_datacheck.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bedpostx_datacheck",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Check the data directory for BEDPOSTX compatibility",
   "command-line": "/usr/local/fsl/bin/bedpostx_datacheck [DATA_DIR]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bedpostx_gpu.json
+++ b/descriptors/fsl/bedpostx_gpu.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bedpostx_gpu",
   "author": "FMRIB Software Library (FSL)",
   "description": "Probabilistic tractography and diffusion MRI fitting tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/Bedpostx",
   "command-line": "bedpostx [SUBJECT_DIRECTORY] [GPU_QUEUE] [NUM_JOBS] [NUM_FIBERS] [ARD_WEIGHT] [BURNIN_PERIOD] [NUM_JUMPS] [SAMPLE_EVERY] [DECONVOLUTION_MODEL] [GRAD_NONLINEAR]",
   "container-image": {
-    "image": "mcin/docker-bedpostx:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bedpostx_single_slice.sh.json
+++ b/descriptors/fsl/bedpostx_single_slice.sh.json
@@ -1,11 +1,10 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "zeropad",
   "description": "Add leading zeros to a number up to the specified length.",
   "command-line": "zeropad [INPUT_NUMBER] [OUTPUT_LENGTH]",
   "container-image": {
-    "image": "local/zeropad:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bet.json
+++ b/descriptors/fsl/bet.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
   "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bet2.json
+++ b/descriptors/fsl/bet2.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "BET (Brain Extraction Tool)",
   "author": "FMRIB Analysis Group, Oxford",
   "description": "Automated brain extraction tool for FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
   "command-line": "bet2 [INPUT_FILEROOT] [OUTPUT_FILEROOT] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OUTLINE_FLAG] [MASK_FLAG] [SKULL_FLAG] [NO_OUTPUT_FLAG] [MESH_FLAG] [HEAD_RADIUS] [SMOOTH_FACTOR] [THRESHOLD_FLAG] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/betsurf.json
+++ b/descriptors/fsl/betsurf.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "2.1",
+  "tool-version": "6.0.5",
   "name": "betsurf",
   "author": "FMRIB Analysis Group, Oxford",
   "description": "BET Surface Finder to extract brain surfaces using T1 and T2 images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
   "command-line": "betsurf [OPTIONS] <t1> [<t2>] <bet_mesh.vtk> <t1_to_standard.mat> <output>",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bianca.json
+++ b/descriptors/fsl/bianca.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bianca",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "BIANCA: Brain Intensity AbNormality Classification Algorithm",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BIANCA",
   "command-line": "/usr/local/fsl/bin/bianca --singlefile=[MASTER_FILE] --labelfeaturenum=[LABEL_FEATURE_NUM] --brainmaskfeaturenum=[BRAIN_MASK_FEATURE_NUM] --querysubjectnum=[QUERY_SUBJECT_NUM] [FEATURE_SUBSET] [MAT_FEATURE_NUM] [SPATIAL_WEIGHT] [PATCH_SIZES] [PATCH_3D] [SELECT_PTS] [TRAINING_PTS] [NON_LES_PTS] [SAVE_CLASSIFIER_DATA] [VERBOSE_FLAG] -o [OUT_NAME]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bianca_cluster_stats.json
+++ b/descriptors/fsl/bianca_cluster_stats.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bianca_cluster_stats",
   "description": "Calculate number of clusters and WMH volume in a BIANCA output map",
   "command-line": "bianca_cluster_stats [BIANCA_OUTPUT_MAP] [THRESHOLD] [MIN_CLUSTER_SIZE] [MASK]",

--- a/descriptors/fsl/bianca_overlap_measures.json
+++ b/descriptors/fsl/bianca_overlap_measures.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bianca_overlap_measures",
   "description": "BIANCA overlap measures script for FSL",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "command-line": "/usr/local/fsl/bin/bianca_overlap_measures [LESION_MASK] [MANUAL_MASK] [OUTPUT_DIR]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/bianca_perivent_deep.json
+++ b/descriptors/fsl/bianca_perivent_deep.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "bianca_perivent_deep",
   "author": "BIANCA Development Team",
   "description": "Separates WMH into periventricular and deep WMH, saves two separate binary images, and calculates volume of total and separate WMHs.",

--- a/descriptors/fsl/calc_grad_perc_dev.json
+++ b/descriptors/fsl/calc_grad_perc_dev.json
@@ -1,14 +1,13 @@
 {
   "name": "calc_grad_perc_dev",
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "author": "Mark Jenkinson, University of Oxford",
   "descriptor-url": "http://example.com/descriptor-url",
   "description": "Compute the gradient percent deviation based on a full warp image from gradient_unwarp.py",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation",
   "command-line": "calc_grad_perc_dev [FULLWARP_IMAGE] [OUT_BASENAME] [--verbose] [--help]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/ccops.json
+++ b/descriptors/fsl/ccops.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "ccops",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "ccops [basename] [infile] [tract_dir] [exclusion_mask] [reorder_seedspace] [reorder_tractspace] [tract_reord] [connexity_constraint] [binarise_val] [matrix_power] [brain_mask] [scheme] [nclusters] [--help]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/checkFEAT.json
+++ b/descriptors/fsl/checkFEAT.json
@@ -21,13 +21,12 @@
     }
   ],
   "schema-version": "0.5",
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "author": "YourName",
   "descriptor-url": "http://example.com/checkFEAT_descriptor.json",
   "url": "http://example.com/checkFEAT",
   "container-image": {
-    "image": "example/checkfeat:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "output-files": [

--- a/descriptors/fsl/cluster.json
+++ b/descriptors/fsl/cluster.json
@@ -456,10 +456,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/cluster2html.json
+++ b/descriptors/fsl/cluster2html.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "cluster2html",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Generates an HTML report from cluster-based FEAT analysis",
   "command-line": "cluster2html [FEATDIR] [INROOT] [STD_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/concat_bvars.json
+++ b/descriptors/fsl/concat_bvars.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "concat_bvars",
   "author": "Unknown",
   "description": "Concatenate multiple .bvars files into a single .bvars file",

--- a/descriptors/fsl/connectedcomp.json
+++ b/descriptors/fsl/connectedcomp.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "connectedcomp",
   "author": "Unknown",
   "description": "Connected component analysis tool",

--- a/descriptors/fsl/convert_warp.json
+++ b/descriptors/fsl/convert_warp.json
@@ -195,10 +195,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/convert_xfm.json
+++ b/descriptors/fsl/convert_xfm.json
@@ -67,10 +67,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "5.0.9",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcp-indi/c-pac:nightly",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/convertwarp.json
+++ b/descriptors/fsl/convertwarp.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk",
   "command-line": "convertwarp [OUTPUT_FILE] [REFERENCE] [PREMAT] [WARP1] [MIDMAT] [WARP2] [POSTMAT] [SHIFT_MAP] [SHIFT_DIR] [JACOBIAN_FLAG] [JSTATS_FLAG] [CONSTRAINJ_FLAG] [JMIN] [JMAX] [ABS_FLAG] [REL_FLAG] [ABSOUT_FLAG] [RELOUT_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/create_lut.json
+++ b/descriptors/fsl/create_lut.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "create_lut",
   "description": "A tool to create lookup tables",
   "command-line": "create_lut [OUTPUT_FILE_ROOT]",

--- a/descriptors/fsl/cutoffcalc.json
+++ b/descriptors/fsl/cutoffcalc.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.1",
+  "tool-version": "6.0.5",
   "name": "cutoffcalc",
   "author": "University of Oxford (Mark Jenkinson and Matthew Webster)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/descriptors/fsl_cutoffcalc.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki",
   "command-line": "cutoffcalc [INPUT_DESIGN] [THRESHOLD] [TR] [LIMIT] [EXAMPLE_SIG] [VERBOSE_FLAG] [DEBUG_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/design_ttest2.json
+++ b/descriptors/fsl/design_ttest2.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "design_ttest2",
   "author": "Analysis Group, FMRIB, Oxford, UK",
   "description": "Command for generating group mean contrasts for a two-sample t-test design.",

--- a/descriptors/fsl/distancemap.json
+++ b/descriptors/fsl/distancemap.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "2.0",
+  "tool-version": "6.0.5",
   "name": "distancemap",
   "author": "University of Oxford (Mark Jenkinson)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "distancemap [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/dtifit.json
+++ b/descriptors/fsl/dtifit.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT",
   "command-line": "dtifit [DATA_FILE] [OUTPUT_BASENAME] [MASK_FILE] [BVEC_FILE] [BVAL_FILE] [VERBOSE_FLAG] [SE_FLAG] [WLS_FLAG] [KURT_FLAG] [KURTDIR_FLAG] [LITTLEBIT_FLAG] [SAVE_TENSOR_FLAG] [ZMIN] [ZMAX] [YMIN] [YMAX] [XMIN] [XMAX] [GRADNONLIN_FILE] [CONFOUND_REGRESSORS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/dtigen.json
+++ b/descriptors/fsl/dtigen.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "dtigen",
   "author": "FSL",
   "description": "Generate diffusion data using tensor model",
   "command-line": "dtigen [TENSOR] [S0] [OUTPUT_DATA] [BVECS] [BVALS] [BRAINMASK] [KURTOSIS] [HELP]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/dual_regression.json
+++ b/descriptors/fsl/dual_regression.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "0.6",
+  "tool-version": "6.0.5",
   "name": "dual_regression",
   "author": "FMRIB Analysis Group",
   "description": "Dual regression algorithm to investigate group-ICA results",
   "url": "https://fsl.fmrib.ox.ac.uk/",
   "command-line": "dual_regression [GROUP_IC_MAPS] [DES_NORM] [DESIGN_MAT] [DESIGN_CON] [N_PERM] [THR] [OUTPUT_DIRECTORY] [INPUT_FILES]",
   "container-image": {
-    "image": "fmrib/fsl",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/easythresh.json
+++ b/descriptors/fsl/easythresh.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "easythresh",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Cluster-based statistical thresholding tool from FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Easythresh",
   "command-line": "easythresh [RAW_ZSTAT] [BRAIN_MASK] [CLUSTER_Z_THRESH] [CLUSTER_PROB_THRESH] [BACKGROUND_IMAGE] [OUTPUT_ROOT] [MM_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/eddy.json
+++ b/descriptors/fsl/eddy.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "eddy",
   "author": "Jesper Andersson (University of Oxford)",
   "description": "A tool for correcting eddy currents and movements in diffusion data",
@@ -7,7 +7,7 @@
   "command-line": "eddy[IMPLEMENTATION] [IMAIN] [MASK] [INDEX] [ACQP] [BVECS] [BVALS] [OUT] [MB] [MB_OFFS] [SLSPEC] [JSON] [MPORDER] [S2V_LAMBDA] [TOPUP] [FIELD] [FIELD_MAT] [FLM] [SLM] [FWHM] [NITER] [S2V_NITER] [CNR_MAPS] [RESIDUALS] [FEP] [INTERP] [S2V_INTERP] [RESAMP] [NVOXHP] [INITRAND] [FF] [REPOL] [OL_NSTD] [OL_NVOX] [OL_TYPE] [OL_POS] [OL_SQR] [ESTIMATE_MOVE_BY_SUSCEPTIBILITY] [MBS_NITER] [MBS_LAMBDA] [MBS_KSP] [DONT_SEP_OFFS_MOVE] [DONT_PEAS] [DATA_IS_SHELLED] [VERBOSE]",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fnndsc/fsl:6.0.5.1-cuda9.1",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/eddy_combine.json
+++ b/descriptors/fsl/eddy_combine.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "eddy_combine",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Combines diffusion data sets with opposite phase encoding directions for use with FSL's EDDY.",
   "command-line": "eddy_combine [PosData] [Posbvals] [Posbvecs] [Pos_SeriesVol] [NegData] [Negbvals] [Negbvecs] [Neg_SeriesVol] [outputpath] [onlymatched_flag]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/eddy_correct.json
+++ b/descriptors/fsl/eddy_correct.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "eddy_correct",
   "author": "FMRIB",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/EDDY",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/EDDY",
   "command-line": "eddy_correct [4D_INPUT] [4D_OUTPUT] [REFERENCE_NO] [INTERP]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/eddy_quad.json
+++ b/descriptors/fsl/eddy_quad.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.3",
+  "tool-version": "6.0.5",
   "name": "eddy_quad",
   "author": "FMRIB Software Library",
   "description": "QUality Assessment for DMRI",
   "command-line": "eddy_quad <eddyBase> --eddyIdx <eddyIndex> --eddyParams <eddyParams> --mask <mask> --bvals <bvals> [OPTIONS]",
   "container-image": {
-    "type": "docker",
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/eddy_squad.json
+++ b/descriptors/fsl/eddy_squad.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "eddy_squad",
   "author": "FMRIB Software Library (FSL)",
   "description": "Study-wise QC for dMRI data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide#EDDY_QC",
   "command-line": "eddy_squad [GROUPING] [GROUP_DB] [UPDATE] [OUTPUT_DIR] list",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/epi_reg.json
+++ b/descriptors/fsl/epi_reg.json
@@ -235,10 +235,10 @@
       "description": "White matter segmentation used in flirt bbr."
     }
   ],
-  "tool-version": "5.0.9",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcp-indi/c-pac:nightly",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/estnoise.json
+++ b/descriptors/fsl/estnoise.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "estnoise",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Estimate noise in 4D fMRI data.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "estnoise [4D_INPUT_DATA] [SPATIAL_SIGMA] [TEMP_HP_SIGMA] [TEMP_LP_SIGMA]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/extracttxt.json
+++ b/descriptors/fsl/extracttxt.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "extracttxt",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Extracts text from a file based on a search word",
   "command-line": "/usr/local/fsl/bin/extracttxt [SEARCH_WORD] [FILE] [NUM_TRAILING_LINES] [RELATIVE_START]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber.json
+++ b/descriptors/fsl/fabber.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "4.0.10-dirty",
+  "tool-version": "6.0.5",
   "name": "fabber",
   "author": "FSL Community",
   "description": "Fabber is a tool for model-based Bayesian analysis of time-series data",

--- a/descriptors/fsl/fabber_asl.json
+++ b/descriptors/fsl/fabber_asl.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "4.0.10-dirty",
+  "tool-version": "6.0.5",
   "name": "fabber_asl",
   "author": "Unknown",
   "description": "Fabber is a tool for automated model fitting of time series data.",
   "url": "https://fabber_tool.website",
   "command-line": "fabber [--listmethods] [--listmodels] [--listparams] [--descparams] [--listoutputs] [--evaluate] [--evaluate-params] [--evaluate-nt] [--simple-output] [--output] [--overwrite] [--link-to-latest] [--method] [--model] [--loadmodels] [--data] [--mask] [--suppdata] [--dump-param-names] [--save-model-fit] [--save-residuals] [--save-model-extras] [--save-mvn] [--save-mean] [--save-std] [--save-var] [--save-zstat] [--save-noise-mean] [--save-noise-std] [--save-free-energy] [--optfile] [--debug]",
   "container-image": {
-    "image": "docker-fabber_asl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_cest.json
+++ b/descriptors/fsl/fabber_cest.json
@@ -1,14 +1,13 @@
 {
-  "tool-version": "4.0.10-dirty",
+  "tool-version": "6.0.5",
   "name": "fabber_cest",
   "author": "FMRIB Centre, University of Oxford",
   "description": "Fabber Model-based Analysis",
   "url": "https://fabber.gitlab.io",
   "command-line": "fabber [--<option> | --<option>=<value> ...]",
   "container-image": {
-    "type": "docker",
-    "image": "fsl/fabber:latest",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/fabber_dce.json
+++ b/descriptors/fsl/fabber_dce.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "4.0.10",
+  "tool-version": "6.0.5",
   "name": "Fabber DCE",
   "author": "FMRIB Analysis Group, University of Oxford",
   "descriptor-url": "https://example.com/fabber_dce_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fabber-core.readthedocs.io/",
   "command-line": "fabber [MODEL] [METHOD] [DATA] --output [OUTPUT_DIR] [OPTIONS]",
   "container-image": {
-    "image": "example/fabber_dce:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_dsc.json
+++ b/descriptors/fsl/fabber_dsc.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "4.0.10",
+  "tool-version": "6.0.5",
   "name": "fabber",
   "author": "FMRIB, University of Oxford",
   "descriptor-url": "https://github.com/ibme-qubic/fabber-core",
@@ -7,8 +7,7 @@
   "url": "https://fabber.readthedocs.io/",
   "command-line": "fabber [OPTIONS]",
   "container-image": {
-    "image": "qubic/fabber:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_dualecho.json
+++ b/descriptors/fsl/fabber_dualecho.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "4.0.10-dirty",
+  "tool-version": "6.0.5",
   "name": "fabber_dualecho",
   "author": "FMRIB Analysis Group, University of Oxford",
   "description": "FMRIB's Advanced Bayesian Estimation and Inference tool for FMRI analysis.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fabber",
   "command-line": "fabber [OUTPUT_DIRECTORY] --method [METHOD] --model [MODEL] --data [DATA] [DATA_ORDER] [MASK_FILE] [MT_LIST] [SUPP_DATA] [OPTIONS_FILE] [HELP_FLAG] [LIST_METHODS_FLAG] [LIST_MODELS_FLAG] [LIST_PARAMS_FLAG] [DESC_PARAMS_FLAG] [LIST_OUTPUTS_FLAG] [EVALUATE] [EVALUATE_PARAMS] [EVALUATE_NT] [SIMPLE_OUTPUT_FLAG] [OVERWRITE_FLAG] [LINK_TO_LATEST_FLAG] [LOAD_MODELS] [DUMP_PARAM_NAMES_FLAG] [SAVE_MODEL_FIT_FLAG] [SAVE_RESIDUALS_FLAG] [SAVE_MODEL_EXTRAS_FLAG] [SAVE_MVN_FLAG] [SAVE_MEAN_FLAG] [SAVE_STD_FLAG] [SAVE_VAR_FLAG] [SAVE_ZSTAT_FLAG] [SAVE_NOISE_MEAN_FLAG] [SAVE_NOISE_STD_FLAG] [SAVE_FREE_ENERGY_FLAG] [DEBUG_FLAG]",
   "container-image": {
-    "image": "fsl/fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_dwi.json
+++ b/descriptors/fsl/fabber_dwi.json
@@ -1,12 +1,12 @@
 {
-  "tool-version": "4.0.10",
+  "tool-version": "6.0.5",
   "name": "fabber_dwi",
   "author": "Release Team",
   "description": "Fabber diffusion-weighted imaging tool for model-based analysis using forward models and different inference methods.",
   "url": "https://www.fmrib.ox.ac.uk/fabber_dwi",
   "command-line": "fabber [PARAMS]",
   "container-image": {
-    "image": "docker.io/fmrib/fabber_dwi:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_pet.json
+++ b/descriptors/fsl/fabber_pet.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "4.0.10-dirty",
+  "tool-version": "6.0.5",
   "name": "fabber_pet",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Fabber Bayesian Model Fitting Tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fabber",
   "command-line": "fabber [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fabber:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_qbold.json
+++ b/descriptors/fsl/fabber_qbold.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "4.0.10",
+  "tool-version": "6.0.5",
   "name": "fabber_qbold",
   "author": "FSL",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fabber",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fabber",
   "command-line": "fabber [--listmethods] [--listmodels] [--listparams] [--descparams] [--listoutputs] [--evaluate] [--evaluate-params] [--evaluate-nt] [--simple-output] [--output] [--overwrite] [--link-to-latest] [--method] [--model] [--loadmodels] [--data] [--data<n>] [--data-order] [--mask] [--mt<n>] [--suppdata] [--dump-param-names] [--save-model-fit] [--save-residuals] [--save-model-extras] [--save-mvn] [--save-mean] [--save-std] [--save-var] [--save-zstat] [--save-noise-mean] [--save-noise-std] [--save-free-energy] [--optfile] [--debug]",
   "container-image": {
-    "image": "fsl/fabber:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fabber_t1.json
+++ b/descriptors/fsl/fabber_t1.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "4.0.10",
+  "tool-version": "6.0.5",
   "name": "fabber_t1",
   "author": "FMRIB Analysis Group",
   "description": "Fabber is a tool for performing model-based analysis of fMRI data, using advanced Bayesian inference techniques.",
   "command-line": "fabber [OUTPUT_DIRECTORY] [METHOD] [MODEL] [DATA_FILE] [DATA_ORDER] [MASK] [MASKED_TIME_POINTS] [SUPP_DATA_FILE] [OVERWRITE] [LINK_TO_LATEST] [SIMPLE_OUTPUT] [LOAD_MODELS] [EVALUATE] [EVALUATE_PARAMS] [EVALUATE_NT] [DUMP_PARAM_NAMES] [SAVE_MODEL_FIT] [SAVE_RESIDUALS] [SAVE_MODEL_EXTRAS] [SAVE_MVN] [SAVE_MEAN] [SAVE_STD] [SAVE_VAR] [SAVE_ZSTAT] [SAVE_NOISE_MEAN] [SAVE_NOISE_STD] [SAVE_FREE_ENERGY] [OPTFILE] [DEBUG]",
   "container-image": {
-    "image": "fmrib/fabber:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fast.json
+++ b/descriptors/fsl/fast.json
@@ -300,10 +300,10 @@
       "description": "Path/name of binary segmented volume file one val for each class  _seg."
     }
   ],
-  "tool-version": "5.0.9",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/fdr.json
+++ b/descriptors/fsl/fdr.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "fdr",
   "author": "University of Oxford (Mark Jenkinson)",
   "description": "False Discovery Rate (FDR) correction tool from FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki",
   "command-line": "fdr -i [INPUT_FILE] [MASK_IMAGE] [Q_VALUE] [OUTPUT_ADJUSTED_IMAGE] [OUTPUT_THRESH_IMAGE] [OUTPUT_ORDER_VALUES] [ONE_MINUS_P_FLAG] [POSITIVE_CORR_FLAG] [INDEPENDENT_FLAG] [CONSERVATIVE_FLAG] [DEBUG_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/feat.json
+++ b/descriptors/fsl/feat.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "feat",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "fMRI Expert Analysis Tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "feat [DESIGN_FSF]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/feat_gm_prepare.json
+++ b/descriptors/fsl/feat_gm_prepare.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "feat_gm_prepare",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Prepare 4D grey matter files for higher-level analysis in FEAT.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "feat_gm_prepare [GM_OUTPUT] [FEAT_DIRS_LIST]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/feat_model.json
+++ b/descriptors/fsl/feat_model.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "feat_model",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Generate design matrices for use by FEAT",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "feat_model [DESIGN_NAME_ROOT] [CONFOUND_MATRIX]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/featquery.json
+++ b/descriptors/fsl/featquery.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "featquery",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT/UserGuide",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "featquery [N_FEATDIRS] [FEATDIRS] [N_STATS] [STATS] [OUTPUT_ROOTNAME] [ATLAS_FLAG] [PERCENT_CONVERT_FLAG] [THRESH_FLAG] [INTERP_THRESH] [TIMESERIES_FLAG] [WEIGHT_FLAG] [BROWSER_FLAG] [MASK] [COORDS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/featregapply.json
+++ b/descriptors/fsl/featregapply.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "featregapply",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Apply registration from FEAT analysis to other images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT",
   "command-line": "featregapply [FEAT_DIRECTORY] [FORCE_FLAG] [CLEANUP_FLAG] [UPSAMPLE_TRILINEAR] [UPSAMPLE_SPLINE] [STANDARD_SPACE_RES] [EXCLUDE_FILTERED_FUNC_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/film_cifti.json
+++ b/descriptors/fsl/film_cifti.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "film_cifti",
   "author": "FSL Community",
   "description": "A tool for statistical analysis of CIFTI files using FILM.",
   "command-line": "film_cifti -i [INPUT_FILENAME] -o [BASENAME] -l [LEFT_SURFACE] -r [RIGHT_SURFACE] [SUSAN_THRESHOLD] [SUSAN_EXTENT] [SURFACE_SIGMA] [SURFACE_EXTENT] [FILM_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/film_gls.json
+++ b/descriptors/fsl/film_gls.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "film_gls",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "General Linear Model fitting with autocorrelation in FMRI",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FILM",
   "command-line": "film_gls [INPUT_FILE] [AC_FLAG] [THRESHOLD] [AR_FLAG] [NOEST_FLAG] [OUTPUT_PW_FLAG] [PAVA_FLAG] [SA_FLAG] [VERBOSE_FLAG] [RESULTS_DIR] [MODE] [INPUT_SURFACE] [MEAN_FUNC_FILE] [MIN_TIMEPOINT_FILE] [PARADIGM_FILE] [T_CONTRASTS_FILE] [F_CONTRASTS_FILE] [EPITH] [MS] [TUKEY] [MT] [VEN] [VEF]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/filmbabe.json
+++ b/descriptors/fsl/filmbabe.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "filmbabe [DATAFILE] [MASK] [DESIGNFILE] [FRF] [VERBOSE_FLAG] [DEBUG_LEVEL] [TIMING_ON_FLAG] [HELP_FLAG] [FLOBS_PRIOR_OFF_FLAG] [FLOBS_DIR] [PRIOR_COVAR_FILE] [PRIOR_MEAN_FILE] [LOG_DIR] [NUM_ITERATIONS] [TEMPORAL_AR_MRF_PREC] [TEMPORAL_AR_FLAG] [NUM_TRACE_SAMPLES] [TEMPORAL_AR_ORDER]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/filmbabescript.json
+++ b/descriptors/fsl/filmbabescript.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "filmbabescript",
   "author": "Author Unknown",
   "description": "A tool/script for processing FEAT directories and FLOBs directories",
   "url": "URL not provided",
   "command-line": "filmbabescript [FEAT_DIR] [FLOBS_DIR]",
   "container-image": {
-    "image": "image-not-provided",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/find_the_biggest.json
+++ b/descriptors/fsl/find_the_biggest.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "find_the_biggest",
   "author": "Unknown",
   "description": "Tool to find the largest volume or surface from a set of inputs",

--- a/descriptors/fsl/first_flirt.json
+++ b/descriptors/fsl/first_flirt.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "first_flirt",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "FLIRT-based image registration tool with additional options for brain extraction and weighting masks",
   "command-line": "first_flirt [INPUT_IMAGE] [OUTPUT_BASENAME] [ALREADY_BRAIN_EXTRACTED_FLAG] [DEBUG_FLAG] [INWEIGHT_FLAG] [STRUCWEIGHT_MASK] [CORT_FLAG] [COST_FUNCTION]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/first_mult_bcorr.json
+++ b/descriptors/fsl/first_mult_bcorr.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "first_mult_bcorr",
   "author": "University of Oxford (Mark Jenkinson)",
   "description": "Part of FSL (ID: 6.0.5:9e026117), first_mult_bcorr converts label images to an output image.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FIRST",
   "command-line": "first_mult_bcorr [INPUT_IMAGE] [CORRECTED_4D_LABELS] [UNCORRECTED_4D_LABELS] [OUTPUT_IMAGE] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/first_roi_slicesdir.json
+++ b/descriptors/fsl/first_roi_slicesdir.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "first_roi_slicesdir",
   "author": "FMRIB Centre, Oxford University",
   "description": "A utility for generating slice directories for FIRST-ROI.",
   "command-line": "first_roi_slicesdir [INPUT_T1_IMAGES] [INPUT_LABEL_IMAGES]",
   "container-image": {
-    "image": "fsl/first:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/first_utils.json
+++ b/descriptors/fsl/first_utils.json
@@ -5,8 +5,7 @@
   "description": "Utilities for handling FIRST's input and output files",
   "command-line": "first_utils [OPTIONAL_ARGS] -i [INPUT] -o [OUTPUT]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/flameo.json
+++ b/descriptors/fsl/flameo.json
@@ -1,12 +1,12 @@
 {
   "name": "FLAMEO",
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "description": "Automatic nipype2boutiques conversion failed.",
   "command-line": "dummy",
   "schema-version": "0.5",
   "container-image": {
-    "type": "docker",
-    "image": "fcpindi/c-pac:latest"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/flirt.json
+++ b/descriptors/fsl/flirt.json
@@ -476,10 +476,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/flirt_average.json
+++ b/descriptors/fsl/flirt_average.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "flirt_average",
   "author": "FMRIB Analysis Group, Oxford Centre for Functional MRI of the Brain",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
   "command-line": "flirt_average [NINPUTS] [INPUT_FILE1] [INPUT_FILE2] ... [OUTPUT_FILE] [REFERENCE] [FLIRT_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fnirt.json
+++ b/descriptors/fsl/fnirt.json
@@ -169,10 +169,10 @@
       "description": "Warped image."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "container/image",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/fnirtfileutils.json
+++ b/descriptors/fsl/fnirtfileutils.json
@@ -5,8 +5,7 @@
   "description": "FNIRT file utilities for FSL - Converts FNIRT warp field coefficients to other formats",
   "command-line": "fnirtfileutils [INPUT_COEFS] [REFERENCE_MASK] [FIELD_OUTPUT] [OUTPUT_FORMAT] [WARP_RES] [KNOT_SPACE] [JACOBIAN_OUTPUT] [JACOBIAN_MATRIX] [WITH_AFF] [VERBOSE] [HELP]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl2ascii.json
+++ b/descriptors/fsl/fsl2ascii.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl2ascii",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fsl2ascii [INPUT_FILE] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslFixText.json
+++ b/descriptors/fsl/fslFixText.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslFixText",
   "author": "FMRIB Software Library (FSL)",
   "description": "Ensures standard UNIX line endings in the output text file",
   "command-line": "fslFixText [INPUT_TEXT_FILE] [OUTPUT_TEXT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_anat.json
+++ b/descriptors/fsl/fsl_anat.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_anat",
   "author": "FMRIB Software Library (FSL) developers",
   "descriptor-url": "https://example.com/fsl_anat_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/fsl_anat",
   "command-line": "fsl_anat [PARAMS] -i [STRUCTURAL_IMAGE] -d [EXISTING_ANAT_DIR]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_boxplot.json
+++ b/descriptors/fsl/fsl_boxplot.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "fsl_boxplot",
   "author": "University of Oxford (Christian F. Beckmann)",
   "descriptor-url": "https://example.com/fsl_boxplot.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki",
   "command-line": "fsl_boxplot --in [INPUT_FILES] --out [OUTPUT_IMAGE] [TITLE] [LEGEND_FILE] [XLABEL] [YLABEL] [PLOT_HEIGHT] [PLOT_WIDTH]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_deface.json
+++ b/descriptors/fsl/fsl_deface.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_deface",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool to deface a structural T1w image.",
   "command-line": "fsl_deface [INPUT_FILE] [OUTPUT_FILE] [CROPPED_DEFACING_FLAG] [DEFACING_MASK] [CROPPED_STRUC] [ORIG_TO_STD_MAT] [ORIG_TO_CROPPED_MAT] [CROPPED_TO_STD_MAT] [SHIFT_NUD] [FRACTIONAL_INTENSITY] [BIAS_CORRECT_FLAG] [CENTER_OF_GRAVITY] [QC_IMAGES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_ents.json
+++ b/descriptors/fsl/fsl_ents.json
@@ -1,6 +1,6 @@
 {
   "name": "fsl_ents",
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "description": "Extract component time series from a MELODIC .ica directory",
   "command-line": "fsl_ents [ICADIR] [COMPONENTS] [OUTFILE] [OVERWRITE] [CONFFILE] [-h]",
   "inputs": [
@@ -69,7 +69,7 @@
   ],
   "container-image": {
     "type": "docker",
-    "image": "mcin/docker-fsl:latest",
+    "image": "mcin/fsl:6.0.5",
     "index": "index.docker.io"
   }
 }

--- a/descriptors/fsl/fsl_gen_3D.json
+++ b/descriptors/fsl/fsl_gen_3D.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_gen_3D",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool to generate a 3D snapshot of a structural image",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "fsl_gen_3D [INPUT_FILE] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_get_standard.json
+++ b/descriptors/fsl/fsl_get_standard.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_get_standard",
   "description": "Generate paths to FSL standard space images",
   "command-line": "fsl_get_standard [IMAGE_TYPE] [RESOLUTION] [VERBOSE_FLAG] [VERSION_FLAG]",

--- a/descriptors/fsl/fsl_glm.json
+++ b/descriptors/fsl/fsl_glm.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "fsl_glm",
   "author": "Christian F. Beckmann",
   "descriptor-url": "N/A",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/GLM",
   "command-line": "fsl_glm -i [INPUT_FILE] -d [DESIGN] -o [OUTPUT_FILE] [CONTRASTS] [MASK] [DOF] [DES_NORM_FLAG] [DAT_NORM_FLAG] [VN_FLAG] [DEMEAN_FLAG] [OUT_COPE] [OUT_Z] [OUT_T] [OUT_P] [OUT_F] [OUT_PF] [OUT_RESIDUALS] [OUT_VARCB] [OUT_SIGSQ] [OUT_DATA] [OUT_VNSCALES] [VX_TEXT] [VX_IMAGES] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_motion_outliers.json
+++ b/descriptors/fsl/fsl_motion_outliers.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_motion_outliers",
   "author": "FMRIB Analysis Group",
   "descriptor-url": "https://example.com/fsl_motion_outliers_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLMotionOutliers",
   "command-line": "fsl_motion_outliers -i [INPUT_4D_IMAGE] -o [OUTPUT_CONFOUND_FILE] [MASK_IMAGE] [SAVE_METRIC_FILE] [SAVE_METRIC_PLOT] [TEMP_PATH] [REFFRMS_FLAG] [DVARS_FLAG] [REFMSE_FLAG] [FD_FLAG] [FDRMS_FLAG] [ABS_THRESH] [NO_MOCO_FLAG] [DUMMY_SCANS] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_mrs.json
+++ b/descriptors/fsl/fsl_mrs.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mrs",
   "author": "FMRIB Centre, University of Oxford",
   "description": "FSL Magnetic Resonance Spectroscopy Wrapper Script",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "fsl_mrs [DATA] [BASIS] [OUTPUT] [ALGO] [IGNORE_METAB] [KEEP_METAB] [COMBINE_METAB] [PPMLIM] [H2O_FILE] [BASELINE_ORDER] [METAB_GROUPS] [ADD_MM_FLAG] [ADD_MM_MEGA_FLAG] [LORENTZIAN_FLAG] [IND_SCALE] [DISABLE_MH_PRIORS_FLAG] [T1_IMAGE] [TE] [TR] [TISSUE_FRAC] [INTERNAL_REF] [WREF_METABOLITE] [REF_PROTONS] [REF_INT_LIMITS] [H2O_SCALE] [REPORT_FLAG] [VERBOSE_FLAG] [OVERWRITE_FLAG] [CONJ_FID] [NO_CONJ_FID] [CONJ_BASIS] [NO_CONJ_BASIS] [NO_RESCALE] [CONFIG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_mrs_preproc.json
+++ b/descriptors/fsl/fsl_mrs_preproc.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mrs_preproc",
   "author": "FMRIB Analysis Group, Oxford University",
   "description": "FSL Magnetic Resonance Spectroscopy - Complete non-edited SVS Preprocessing",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "fsl_mrs_preproc [DATA] [REFERENCE] [OUTPUT] [QUANT] [ECC] [NOAVERAGE] [HLSVD] [LEFTSHIFT] [T1] [VERBOSE] [CONJUGATE] [OVERWRITE] [REPORT] [CONFIG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_mrs_proc.json
+++ b/descriptors/fsl/fsl_mrs_proc.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mrs_proc",
   "author": "FMRIB Centre, University of Oxford",
   "description": "FSL Magnetic Resonance Spectroscopy - Preprocessing",

--- a/descriptors/fsl/fsl_mrs_sim.json
+++ b/descriptors/fsl/fsl_mrs_sim.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mrs_sim",
   "author": "FSL",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/fsl_mrs",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/fsl_mrs",
   "command-line": "fsl_mrs_sim [SEQUENCE] [METAB] [METAB_FILE] [CUSTOM_SPINSYS] [OUTPUT_FOLDER] [RAW_FLAG] [JMRUI_FLAG] [ADDREF_FLAG] [AUTOPHASE_PPM] [LCM_LOC] [MM_JSON] [OUTPUT_TE] [OVERWRITE_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "fsl:fsl_mrs_sim",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_mrsi.json
+++ b/descriptors/fsl/fsl_mrsi.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mrsi",
   "author": "FMRIB Centre",
   "description": "FSL Magnetic Resonance Spectroscopy Imaging Wrapper Script",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "fsl_mrsi --data [DATA] --basis [BASIS] --mask [MASK] --output [OUTPUT] [ALGO] [IGNORE_METAB] [KEEP_METAB] [COMBINE_METAB] [PPMLIM] [H2O] [BASELINE_ORDER] [METAB_GROUPS] [ADD_MM] [LORENTZIAN] [IND_SCALE] [DISABLE_MH_PRIORS] [TE] [TR] [TISSUE_FRAC] [INTERNAL_REF] [WREF_METABOLITE] [REF_PROTONS] [REF_INT_LIMITS] [H2O_SCALE] [REPORT] [VERBOSE] [OVERWRITE] [SINGLE_PROC] [CONJ_FID] [NO_CONJ_FID] [CONJ_BASIS] [NO_CONJ_BASIS] [NO_RESCALE] [CONFIG]",
   "container-image": {
-    "image": "fmrib/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_mvlm.json
+++ b/descriptors/fsl/fsl_mvlm.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_mvlm",
   "author": "Christian F. Beckmann",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "fsl_mvlm -i [INPUT_FILE] -o [BASENAME_OUTPUT_FILES] [ALGORITHM] [DESIGN_MATRIX] [MASK_IMAGE] [DESIGN_NORMALIZATION] [VN_PERFORM] [DEMEAN] [NMF_DIM] [NMF_ITT] [VERBOSE] [OUT_DATA] [OUT_VNSCALES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_prepare_fieldmap.json
+++ b/descriptors/fsl/fsl_prepare_fieldmap.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_prepare_fieldmap",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PrepareFieldmap",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PrepareFieldmap",
   "command-line": "fsl_prepare_fieldmap [SCANNER] [PHASE_IMAGE] [MAGNITUDE_IMAGE] [OUT_IMAGE] [DELTA_TE] [NOCHECK_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_reg.json
+++ b/descriptors/fsl/fsl_reg.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_reg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Image registration using FSL tools",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT",
   "command-line": "fsl_reg [INPUT_FILE] [REFERENCE_FILE] [OUTPUT_FILE] [ESTIMATE_ONLY_FLAG] [AFFINE_ONLY_FLAG] [FNIRT_FA_CONFIG_FLAG] [FLIRT_OPTIONS] [FNIRT_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_regfilt.json
+++ b/descriptors/fsl/fsl_regfilt.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslRegfilt",
   "command-line": "fsl_regfilt -i [INPUT_FILE] -d [DESIGN_FILE] -o [OUTPUT_FILE] [MASK_FILE] [FILTER] [FREQ_FILTER_FLAG] [FREQ_IC_FLAG] [FREQ_IC_SMOOTH] [FTHRESH] [FTHRESH2] [VN_FLAG] [VERBOSE_FLAG] [AGGRESSIVE_FLAG] [HELP_FLAG] [OUT_DATA] [OUT_MIX] [OUT_VNSCALES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_sbca.json
+++ b/descriptors/fsl/fsl_sbca.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "fsl_sbca",
   "author": "Christian F. Beckmann",
   "description": "Performs seed-based correlation analysis on FMRI data using either a single seed coordinate or a seed mask",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SBCA",
   "command-line": "fsl_sbca -i [INPUT_FILE] -s [SEED_FILE] -t [TARGET_FILE] -o [OUTPUT_BASENAME] [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_schurprod.json
+++ b/descriptors/fsl/fsl_schurprod.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "fsl_schurprod",
   "author": "Christian F. Beckmann",
   "description": "Generates element-wise matrix products or product of matrices against vectors from 4D data",
   "command-line": "fsl_schurprod -i [INPUT_FILE] -d [DESIGN_FILE] -o [OUTPUT_FILE] [REGRESSION_FLAG] [INDEX] [MASK_FILE] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_sub.json
+++ b/descriptors/fsl/fsl_sub.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_sub",
   "author": "FMRIB (Oxford University)",
   "description": "FSL cluster submission tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslSub",
   "command-line": "fsl_sub [OPTIONS]",
   "container-image": {
-    "image": "fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsl_sub_config.json
+++ b/descriptors/fsl/fsl_sub_config.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_sub_config",
   "author": "FMRIB Software Library (FSL)",
   "description": "FSL cluster submission configuration examples",

--- a/descriptors/fsl/fsl_sub_report.json
+++ b/descriptors/fsl/fsl_sub_report.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsl_sub_report",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "FSL cluster job reporting tool",

--- a/descriptors/fsl/fsl_tsplot.json
+++ b/descriptors/fsl/fsl_tsplot.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "fsl_tsplot",
   "author": "University of Oxford (Christian F. Beckmann)",
   "description": "Timeseries plotting tool from FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "fsl_tsplot [INPUT_FILES] [OUTPUT_FILE] [TITLE] [LEGEND_FILE] [LABELS] [YMIN] [YMAX] [XLABEL] [YLABEL] [HEIGHT] [WIDTH] [UNIT] [PRECISION] [SCI_FLAG] [START_COL] [END_COL]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fsladd.json
+++ b/descriptors/fsl/fsladd.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fsladd",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool for adding or averaging multiple input volumes.",

--- a/descriptors/fsl/fslanimate.json
+++ b/descriptors/fsl/fslanimate.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslanimate",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool for creating animations from imaging data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki",
   "command-line": "fslanimate [INPUT] [OUTPUT] [TMPDIR]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslascii2img.json
+++ b/descriptors/fsl/fslascii2img.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslascii2img",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Convert data from ASCII format to NIfTI format",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslascii2img [INPUT_FILE] [XSIZE] [YSIZE] [ZSIZE] [TSIZE] [XDIM] [YDIM] [ZDIM] [TR] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslcc.json
+++ b/descriptors/fsl/fslcc.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "fslcc [FIRST_INPUT] [SECOND_INPUT] [MASK] [NOABS_FLAG] [NODEMEAN_FLAG] [THRESHOLD] [DECIMAL_PLACES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslchfiletype.json
+++ b/descriptors/fsl/fslchfiletype.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslchfiletype",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool to change the file type of an image file or copy it to a new file.",

--- a/descriptors/fsl/fslcomplex.json
+++ b/descriptors/fsl/fslcomplex.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslcomplex",
   "author": "FMRIB Analysis Group, Oxford University, UK",
   "description": "Tool for manipulating complex-valued MR data",

--- a/descriptors/fsl/fslcpgeom.json
+++ b/descriptors/fsl/fslcpgeom.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslcpgeom",
   "author": "FMRIB Centre",
   "description": "FSL tool to copy image geometry from one file to another.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils#FSL-Extended-Utilities",
   "command-line": "fslcpgeom [SOURCE_FILE] [DESTINATION_FILE] [DIMENSIONS_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslcreatehd.json
+++ b/descriptors/fsl/fslcreatehd.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslcreatehd",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fslcreatehd.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLUtils",
   "command-line": "fslcreatehd [XSIZE] [YSIZE] [ZSIZE] [TSIZE] [XVOXSIZE] [YVOXSIZE] [ZVOXSIZE] [TR] [XORIGIN] [YORIGIN] [ZORIGIN] [DATATYPE] [HEADERNAME] [XML_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslfft.json
+++ b/descriptors/fsl/fslfft.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslfft",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "A tool to compute the Fourier transform of an input volume and save the result in an output volume.",

--- a/descriptors/fsl/fslhd.json
+++ b/descriptors/fsl/fslhd.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslhd",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fslhd.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils#FSLHD",
   "command-line": "fslhd [XML_FLAG] [INPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslinfo.json
+++ b/descriptors/fsl/fslinfo.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslinfo",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Display information about NIFTI-1 image file",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslinfo [FILENAME]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslinterleave.json
+++ b/descriptors/fsl/fslinterleave.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslinterleave",
   "author": "FMRIB Software Library (FSL)",
   "description": "Interleaves two input images slice-by-slice to produce an output image.",
   "url": "https://fsl.fmrib.ox.ac.uk",
   "command-line": "fslinterleave [IN1] [IN2] [OUT] [REVERSE_SLICE_ORDER_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslmaths.json
+++ b/descriptors/fsl/fslmaths.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslmaths",
   "author": "FMRIB Analysis Group, Oxford University, UK",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslmaths [INPUT_FILE] [OPERATIONS] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslmeants.json
+++ b/descriptors/fsl/fslmeants.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslmeants -i [INPUT_IMAGE] [OUTPUT] [MASK] [COORDINATES] [USEMM_FLAG] [SHOWALL_FLAG] [EIGENV_FLAG] [EIGENVARIATES_ORDER] [NO_BIN_FLAG] [LABEL_IMAGE] [TRANSPOSE_FLAG] [WEIGHTED_MEAN_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslmerge.json
+++ b/descriptors/fsl/fslmerge.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslmerge",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "FSL tool to concatenate images in various dimensions",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslmerge [MERGE_DIRECTION] [OUTPUT_FILE] [INPUT_FILES] [TR_VALUE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslmodhd.json
+++ b/descriptors/fsl/fslmodhd.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslmodhd",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "A tool for modifying header information of NIfTI images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslmodhd [IMAGE] [KEYWORD] [VALUE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslnvols.json
+++ b/descriptors/fsl/fslnvols.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslnvols",
   "author": "FMRIB Centre, University of Oxford",
   "description": "Retrieve the number of volumes in a 4D NIfTI file",
   "command-line": "fslnvols [INPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslorient.json
+++ b/descriptors/fsl/fslorient.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslorient",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "FSL tool to manipulate NIfTI header orientation information",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslorient [MAIN_OPTION] [FILENAME]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslpspec.json
+++ b/descriptors/fsl/fslpspec.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslpspec",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Estimate the power spectrum of 4D fMRI time series data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "fslpspec [INPUT_FILE] [OUTPUT_FILE] [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslreorient2std.json
+++ b/descriptors/fsl/fslreorient2std.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslreorient2std",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "A tool for reorienting an image to match the approximate orientation of standard template images (MNI152).",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils#fslreorient2std",
   "command-line": "fslreorient2std [INPUT_IMAGE] [OUTPUT_IMAGE] [-m MATRIX_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslroi.json
+++ b/descriptors/fsl/fslroi.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslroi",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Extracts a region of interest (ROI) from an image",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslroi [INPUT_FILE] [OUTPUT_FILE] [XMIN] [XSIZE] [YMIN] [YSIZE] [ZMIN] [ZSIZE] [TMIN] [TSIZE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslselectvols.json
+++ b/descriptors/fsl/fslselectvols.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "fslselectvols [INPUT_FILE] [OUTPUT_FILE] [VOLS_LIST] [OUTPUT_MEAN_FLAG] [OUTPUT_VARIANCE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslsize.json
+++ b/descriptors/fsl/fslsize.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslsize",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool to output the size of an image file in FSL",
   "command-line": "fslsize [INPUT_FILE] [SHORT_FORMAT_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslslice.json
+++ b/descriptors/fsl/fslslice.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslslice",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool to extract all slices from a 3D volume and store as 2D images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslslice [VOLUME] [OUTPUT_BASENAME]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslsmoothfill.json
+++ b/descriptors/fsl/fslsmoothfill.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "fslsmoothfill",
   "author": "University of Oxford (Mark Jenkinson)",
   "description": "Smoothfill is a tool designed to fill in holes in images by smoothly interpolating the pixel values.",
   "command-line": "smoothfill -i [INPUT_IMAGE] -m [MASK_IMAGE] -o [OUTPUT_IMAGE] [NUMBER_OF_ITERATIONS] [DEBUG_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslsplit.json
+++ b/descriptors/fsl/fslsplit.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslsplit",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Split a 4D image into separate volumes or a 3D image into separate slices",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslsplit [INPUT_FILE] [OUTPUT_BASENAME] [SEPARATION_AXIS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslstats.json
+++ b/descriptors/fsl/fslstats.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslstats",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://example.com/fslstats-descriptor.json",

--- a/descriptors/fsl/fslswapdim.json
+++ b/descriptors/fsl/fslswapdim.json
@@ -1,13 +1,12 @@
 {
   "name": "fslswapdim",
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Swap dimensions of an image volume",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslswapdim [INPUT_FILE] [AXIS_A] [AXIS_B] [AXIS_C] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslswapdim_exe.json
+++ b/descriptors/fsl/fslswapdim_exe.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslswapdim_exe",
   "author": "FMRIB Centre, Oxford University",
   "description": "Tool to swap the x, y, z axes dimensions of an image",
   "command-line": "fslswapdim_exe [INPUT_FILE] [AXIS_A] [AXIS_B] [AXIS_C] [OUTPUT_FILE] [CHECK_LR_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslval.json
+++ b/descriptors/fsl/fslval.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslval",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://example.com/fslval.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "fslval [INPUT_FILE] [KEYWORD]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslvbm_1_bet.json
+++ b/descriptors/fsl/fslvbm_1_bet.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslvbm_1_bet",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Brain extraction for VBM using FSL BET",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLVBM",
   "command-line": "fslvbm_1_bet [BET_OPTION] [BET_PARAMETERS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslvbm_2_template.json
+++ b/descriptors/fsl/fslvbm_2_template.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslvbm_2_template",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLVBM",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLVBM",
   "command-line": "fslvbm_2_template [ARCH] [COPROCESSOR] [COPROCESSOR_MULTI] [COPROCESSOR_CLASS] [COPROCESSOR_TOOLKIT] [JOBHOLD] [ARRAY_HOLD] [LOGDIR] [MAILOPTIONS] [MAILTO] [NAME] [PRIORITY] [QUEUE] [RESOURCE] [DELETE_JOB] [GB] [PARALLELENV] [THREADS] [ARRAY_TASK] [ARRAY_NATIVE] [NUMBER] [COPROCESSOR_NAME] [PROJECT] [MINUTES] [JOB_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/fslvbm_3_proc.json
+++ b/descriptors/fsl/fslvbm_3_proc.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "fslvbm_3_proc",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Pipeline for voxel-based morphometry analysis using FSL tools",
   "command-line": "fsl_sub [ARCH] [COPROCESSOR] [COPROCESSOR_MULTI] [COPROCESSOR_CLASS_STRICT] [COPROCESSOR_TOOLKIT] [JOBHOLD] [ARRAY_HOLD] [LOGDIR] [MAILOPTIONS] [MAILTO] [NAME] [PRIORITY] [QUEUE] [RESOURCE] [DELETE_JOB] [GB] [PARALLELENV] [THREADS] [ARRAY_TASK] [ARRAY_NATIVE] [NUMBER] [COPROCESSOR_NAME] [PROJECT] [MINUTES] [CONFIG_FILE] [COMMAND]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "schema-version": "0.5",

--- a/descriptors/fsl/ftoz.json
+++ b/descriptors/fsl/ftoz.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "ftoz",
   "author": "Unknown",
   "description": "Convert F-statistics to Z-scores.",

--- a/descriptors/fsl/fugue.json
+++ b/descriptors/fsl/fugue.json
@@ -379,10 +379,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/generate_brain.json
+++ b/descriptors/fsl/generate_brain.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FAST",
   "command-line": "fast [CLASS_NUMBER] [ITER_NUMBER] [LOWPASS_EXTENT] [IMAGE_TYPE] [INITIAL_SEG_SMOOTHNESS] [SEGMENTS_FLAG] [INIT_PRIORS] [ALT_PRIORS] [NOPRIOR_FLAG] [BIAS_FIELD_FLAG] [B_CORRECTED_FLAG] [NO_BIAS_FLAG] [CHANNELS_NUMBER] [OUTPUT_BASE] [USE_PRIOR_FLAG] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [FIXED_ITERS] [SEG_SMOOTHNESS] [VERBOSE_FLAG] [HELP_FLAG] [MANUAL_SEG] [PROB_MAPS_FLAG] [INPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/glm.json
+++ b/descriptors/fsl/glm.json
@@ -313,10 +313,10 @@
       "list": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/gps.json
+++ b/descriptors/fsl/gps.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "gps",
   "author": "University of Oxford (Jesper Andersson)",
   "description": "Generate set of diffusion gradient directions",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "gps [NDIR] [OPTIMIZE_WHOLE_SPHERE] [OUTPUT] [RANSEED] [INIT] [REPORT] [VERBOSE] [HELP]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/halfcosbasis.json
+++ b/descriptors/fsl/halfcosbasis.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "halfcosbasis [HRF_PARAM_FILE] [VERBOSE_FLAG] [DEBUG_LEVEL] [TIMING_ON_FLAG] [LOG_DIR] [NUM_HRF_SAMPLES] [NUM_HRF_BASIS_FUNCS] [NUM_SECS] [TEMP_RES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/hist2prob.json
+++ b/descriptors/fsl/hist2prob.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "hist2prob",
   "description": "Converts a histogram image to a probability map based on specified thresholds",
   "command-line": "hist2prob [IMAGE] [SIZE] [LOW_THRESH] [HIGH_THRESH]",

--- a/descriptors/fsl/ica_aroma.json
+++ b/descriptors/fsl/ica_aroma.json
@@ -176,10 +176,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/image_stats.json
+++ b/descriptors/fsl/image_stats.json
@@ -66,10 +66,10 @@
       "description": "Any value. Stats output."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/imcp.json
+++ b/descriptors/fsl/imcp.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "imcp",
   "author": "Unknown",
   "description": "Copy images from one location to another",

--- a/descriptors/fsl/img2imgcoord.json
+++ b/descriptors/fsl/img2imgcoord.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "img2imgcoord",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool for transforming coordinates between images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
   "command-line": "img2imgcoord [OPTIONS] [COORDINATES_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/img2stdcoord.json
+++ b/descriptors/fsl/img2stdcoord.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "img2stdcoord",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Transforms image coordinates using standard space transformations.",

--- a/descriptors/fsl/imglob.json
+++ b/descriptors/fsl/imglob.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "imglob",
   "author": "Software Author",
   "description": "Tool for generating image lists with specific extensions.",

--- a/descriptors/fsl/imln.json
+++ b/descriptors/fsl/imln.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "imln",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Creates a link (called file2) to file1",

--- a/descriptors/fsl/immv.json
+++ b/descriptors/fsl/immv.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "immv",
   "author": "Unknown",
   "description": "Moves images from one file or directory to another.",
   "command-line": "immv [SOURCE_FILES] [DESTINATION]",
   "container-image": {
-    "image": "docker/immv:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/imrm.json
+++ b/descriptors/fsl/imrm.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "imrm",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Remove specified image files.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "/usr/local/fsl/bin/imrm [IMAGES_TO_REMOVE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/inv_warp.json
+++ b/descriptors/fsl/inv_warp.json
@@ -109,10 +109,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/invfeatreg.json
+++ b/descriptors/fsl/invfeatreg.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "invfeatreg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/Examples",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT",
   "command-line": "invwarp -w [WARP_FILE] -r [REFERENCE] -o [OUTPUT_FILE] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/invwarp.json
+++ b/descriptors/fsl/invwarp.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "new_invwarp",
   "author": "University of Oxford (Jesper Andersson)",
   "description": "Inverse warp tool from FSL suite",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT",
   "command-line": "invwarp -w [WARP_VOL] -o [OUT_VOL] -r [REF_VOL] [REL_FLAG] [ABS_FLAG] [NOCONSTRAINT_FLAG] [JMIN] [JMAX] [DEBUG_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/invwarp_exe.json
+++ b/descriptors/fsl/invwarp_exe.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UsersGuide#A--invwarp",
   "command-line": "invwarp -w [WARP_FILE] -o [OUT_FILE] -r [REF_FILE] [REL_FLAG] [ABS_FLAG] [NITER] [REGULARISE] [INITWARP] [NOCONSTRAINT] [JMIN] [JMAX] [DEBUG_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/label2surf.json
+++ b/descriptors/fsl/label2surf.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "label2surf --surf [INPUT_SURFACE] --out [OUTPUT_SURFACE] --labels [LABELS] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/lesion_filling.json
+++ b/descriptors/fsl/lesion_filling.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "lesion_filling",
   "author": "University of Oxford (Mark Jenkinson & Taylor Hanayik)",
   "description": "Lesion filling tool as part of FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/LESION_FILLING",
   "command-line": "lesion_filling [INPUT_IMAGE] [OUTPUT_IMAGE] [LESION_MASK_IMAGE] [WHITE_MATTER_MASK_IMAGE] [VERBOSE_FLAG] [COMPONENTS_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/make_bianca_mask.json
+++ b/descriptors/fsl/make_bianca_mask.json
@@ -1,11 +1,10 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "make_bianca_mask",
   "description": "A script for generating BIANCA masks",
   "command-line": "/usr/local/fsl/bin/make_bianca_mask <Usage:> <Main bet2 options> <Variations on default bet2 functionality (mutually exclusive options):> <Miscellaneous options:>",
   "container-image": {
-    "image": "fsl-make-bianca-mask:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/make_dyadic_vectors.json
+++ b/descriptors/fsl/make_dyadic_vectors.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "make_dyadic_vectors",
   "author": "Unknown",
   "description": "Generate dyadic vectors from theta and phi volumes.",

--- a/descriptors/fsl/makerot.json
+++ b/descriptors/fsl/makerot.json
@@ -1,12 +1,11 @@
 {
   "name": "makerot",
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "author": "Mark Jenkinson, University of Oxford",
   "description": "Tool to create a rotation matrix for a given angle and axis of rotation.",
   "command-line": "makerot [AXIS] [COV] [CENTER] [OUTPUT_FILE] [VERBOSE_FLAG] [HELP_FLAG] [THETA]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/maskdyads.json
+++ b/descriptors/fsl/maskdyads.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "maskdyads",
   "author": "Author Name",
   "description": "Tool to mask dyads with threshold",

--- a/descriptors/fsl/match_smoothing.json
+++ b/descriptors/fsl/match_smoothing.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "match_smoothing",
   "description": "Computes the smoothing sigma needed to be applied to structural data to match a given functional data smoothing level.",
   "command-line": "match_smoothing <example_func> <func_smoothing_FWHM_in_mm> <example_structural> <standard_space_resolution>",

--- a/descriptors/fsl/maths.json
+++ b/descriptors/fsl/maths.json
@@ -1,12 +1,12 @@
 {
   "name": "fslmaths",
-  "tool-version": "6.0",
+  "tool-version": "6.0.5",
   "description": "FSL utility for image arithmetic, statistics, and mathematical operations",
   "command-line": "fslmaths [DATATYPE_INTERNAL] [INPUTS] [OPERATIONS] [OUTPUT] [OUTPUT_DATATYPE]",
   "author": "FSL Team",
   "container-image": {
-    "type": "docker",
-    "image": "fcpindi/c-pac:latest"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "schema-version": "0.5",
   "inputs": [

--- a/descriptors/fsl/mccutup.json
+++ b/descriptors/fsl/mccutup.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "mccutup",
   "author": "FSL",
   "description": "FSL mccutup tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "/usr/local/fsl/bin/mccutup [OPTIONS] <input>",
   "container-image": {
-    "image": "fsl_image",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/mcflirt.json
+++ b/descriptors/fsl/mcflirt.json
@@ -254,12 +254,11 @@
       "description": "Variance image."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "type": "docker",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "tags": {
     "domain": ["neuroinformatics", "mri"]

--- a/descriptors/fsl/mean.json
+++ b/descriptors/fsl/mean.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "mean [DATA_FILE] [MASK_FILE] [VERBOSE_FLAG] [DEBUG_LEVEL] [TIMING_FLAG] [LOG_DIR] [FORCEDIR_FLAG] [INFERENCE_TECH] [NUM_JUMPS] [NUM_BURNIN] [NUM_SAMPLE_EVERY] [NUM_UPDATE_PROPOSALEVERY] [ACCEPTANCE_RATE] [SEED] [ERROR_PREC] [NOAMP_FLAG] [PRIOR_MEAN] [PRIOR_STD]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/medianfilter.json
+++ b/descriptors/fsl/medianfilter.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "medianfilter",
   "author": "Unknown",
   "description": "A tool to perform 26 neighbourhood median filtering on an input image.",
   "command-line": "medianfilter [INPUT_FILE] [OUTPUT_FILE]",
   "container-image": {
-    "image": "your-default-docker-image:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/melodic.json
+++ b/descriptors/fsl/melodic.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "3.15",
+  "tool-version": "6.0.5",
   "name": "melodic",
   "author": "Christian F. Beckmann, University of Oxford",
   "description": "Multivariate Exploratory Linear Optimised Decomposition into Independent Components",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/MELODIC",
   "command-line": "melodic [INFILE] [OUTDIR] [MASK] [DIM] [APPROACH] [VN] [REPORT] [CIFTI] [NOMASK] [UPDATE_MASK] [NOBET] [BGTHRESHOLD] [DIMEST] [SEP_VN] [DISABLE_MIGP] [MIGP_N] [MIGP_SHUFFLE] [MIGP_FACTOR] [NUM_ICS] [NL] [COVARWEIGHT] [EPS_RANK1] [EPS] [MAXIT] [MAXRESTART] [MMTHRESH] [NO_MM] [ICS] [MIX] [SMODE] [FILTER] [BGIMAGE] [TR] [LOGPOWER] [TDES] [TCON] [SDES] [SCON] [OUNMIX] [OSTATS] [OPCA] [OWHITE] [OORIG] [OMEAN] [VERSION] [COPYRIGHT] [DEBUG] [REPORT_MAPS] [KEEP_MEANVOL]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/merge.json
+++ b/descriptors/fsl/merge.json
@@ -88,10 +88,10 @@
       "one-is-required": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/merge_mrs_reports.json
+++ b/descriptors/fsl/merge_mrs_reports.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "merge_mrs_reports",
   "author": "FSL",
   "description": "FSL Magnetic Resonance Spectroscopy - Merge HTML reports based on filename in directory.",
   "command-line": "merge_mrs_reports [INPUT_FILES] --description [DESCRIPTION] [OUTPUT_DIR] [OUTPUT_FILENAME] [DELETE_FLAG]",
   "container-image": {
-    "image": "fsl/merge-mrs-reports:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/midtrans.json
+++ b/descriptors/fsl/midtrans.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "midtrans [OPTIONS] [TRANSFORM1] [TRANSFORM2] ... [TRANSFORMN]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/mist_FA_reg.json
+++ b/descriptors/fsl/mist_FA_reg.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "mist_FA_reg",
   "author": "Unknown",
   "description": "Tool for registering FA volumes to a reference T1 volume",

--- a/descriptors/fsl/mist_display.json
+++ b/descriptors/fsl/mist_display.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "mist_display",
   "author": "Unknown",
   "descriptor-url": "http://example.com",

--- a/descriptors/fsl/mm.json
+++ b/descriptors/fsl/mm.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/MM",
   "command-line": "mm [SPATIAL_DATA_FILE] [MASK_FILE] [VERBOSE_FLAG] [DEBUG_LEVEL] [TIMING_FLAG] [EXAMPLE_EPI_FILE] [LOG_DIRECTORY] [NONSPATIAL_FLAG] [FIX_MRF_PREC_FLAG] [MRF_PREC_START] [MRF_PREC_MULTIPLIER] [INIT_MULTIPLIER] [NO_UPDATE_THETA_FLAG] [ZFSTAT_FLAG] [PHI] [NITERS] [THRESHOLD]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/morph_kernel.json
+++ b/descriptors/fsl/morph_kernel.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "morph_kernel",
   "author": "Author Name",
   "description": "Tool to generate morphological kernels",
   "command-line": "morph_kernel [CUBE_SIDE_LENGTH] [SPHERE_RADIUS]",
   "container-image": {
-    "image": "yourdockerhub/morph_kernel:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/mp_diffpow.sh.json
+++ b/descriptors/fsl/mp_diffpow.sh.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "mp_diff",
   "author": "Unknown",
   "description": "Generates a file with specific motion parameter calculations useful for accounting for 'spin history' effects and other variations not accounted for by motion correction.",
   "command-line": "mp_diff [REG_FILE] [DIFF_REG_FILE]",
   "container-image": {
-    "image": "your-docker-repo/mp_diff:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/mrsi_segment.json
+++ b/descriptors/fsl/mrsi_segment.json
@@ -1,13 +1,12 @@
 {
   "name": "mrsi_segment",
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "author": "FSL Team",
   "description": "FSL Magnetic Resonance Spectroscopy - register fast segmentation to MRSI.",
   "command-line": "mrsi_segment [MRSI] [--t1 T1] [--anat ANAT] [--output OUTPUT] [--filename FILENAME]",
   "container-image": {
-    "type": "docker",
-    "image": "fsl/fsl:latest",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/msm.json
+++ b/descriptors/fsl/msm.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "msm",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/MSM",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/MSM",
   "command-line": "msm [INPUT_MESH] --out [OUTPUT_BASENAME] [REFERENCE_MESH] [INPUT_DATA] [REFERENCE_DATA] [TRANSFORMED_SOURCE] [INPUT_MESH_REGISTER] [INPUT_WEIGHT] [REFERENCE_WEIGHT] [OUTPUT_FORMAT] [CONFIG_FILE] [RESOLUTION_LEVELS] [OUTPUT_SMOOTHING] [HELP_FLAG] [VERBOSE_FLAG] [PRINT_OPTIONS_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/new_invwarp.json
+++ b/descriptors/fsl/new_invwarp.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "invwarp",
   "author": "University of Oxford (Jesper Andersson)",
   "description": "Tool for inverting warp fields in FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT/UserGuide#Using_invwarp",
   "command-line": "invwarp --warp [WARP_FILE] --out [OUT_FILE] --ref [REF_FILE] [RELATIVE_WARP_FLAG] [ABSOLUTE_WARP_FLAG] [NO_CONSTRAINT_FLAG] [MIN_JACOBIAN] [MAX_JACOBIAN] [DEBUG_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/old_betall.json
+++ b/descriptors/fsl/old_betall.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "old_betall",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Automated brain extraction tool for FSL involving both T1 and T2 images",
   "command-line": "betall [T1_FILEROUT] [T2_FILEROUT]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/overlay.json
+++ b/descriptors/fsl/overlay.json
@@ -139,10 +139,10 @@
       "mutually-exclusive": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/oxford_asl.json
+++ b/descriptors/fsl/oxford_asl.json
@@ -1,6 +1,6 @@
 {
   "command-line": "oxford_asl -i <asl_data> -o <output_dir_name> [options]",
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "oxford_asl",
   "author": "FMRIB Centre, University of Oxford",
   "description": "Calculate perfusion maps from ASL data",

--- a/descriptors/fsl/pairreg.json
+++ b/descriptors/fsl/pairreg.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "pairreg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://example.com/descriptors/pairreg.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
   "command-line": "/usr/local/fsl/bin/pairreg [BRAIN1] [BRAIN2] [SKULL1] [SKULL2] [OUTPUTMATRIX] [FLIRT_ARGS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/perfusion_subtract.json
+++ b/descriptors/fsl/perfusion_subtract.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "perfusion_subtract",
   "description": "Subtract control images from tag images in 4D perfusion data.",
   "command-line": "perfusion_subtract [4D_INPUT] [4D_OUTPUT] [CONTROL_FIRST_FLAG]",

--- a/descriptors/fsl/pngappend.json
+++ b/descriptors/fsl/pngappend.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "pngappend",
   "author": "Unknown",
   "description": "Append PNG files horizontally and/or vertically into a new PNG (or GIF) file",

--- a/descriptors/fsl/pnm_evs.json
+++ b/descriptors/fsl/pnm_evs.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "2.0",
+  "tool-version": "6.0.5",
   "name": "pnm_evs",
   "author": "University of Oxford (Mark Jenkinson)",
   "description": "PNM EVs: Generates physiological noise regressors for fMRI data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PNM",
   "command-line": "pnm_evs [INPUT_FILE] [OUTPUT_FILE] [TR] [CARDIAC] [RESPIRATORY] [OC] [OR] [MULTC] [MULTR] [CSF_MASK] [RVT] [HEARTRATE] [RVTSMOOTH] [HEARTRATESMOOTH] [SLICE_DIR] [SLICE_ORDER] [SLICE_TIMING] [DEBUG_FLAG] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/pnm_stage1.json
+++ b/descriptors/fsl/pnm_stage1.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "popp",
   "author": "University of Oxford (Mark Jenkinson)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_popp.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PNM#The_popp_program",
   "command-line": "popp [INPUT_FILE] [OUTPUT_BASENAME] [OPTIONAL_ARGUMENTS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/pointflirt.json
+++ b/descriptors/fsl/pointflirt.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "pointflirt",
   "author": "Mark Jenkinson, University of Oxford",
   "description": "A tool to align point coordinates between volumes and compute affine transformation matrices.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "pointflirt -i [INVOL_COORDS] -r [REFVOL_COORDS] -o [OUT_MATRIX] [USE_VOX] [VOL_INPUT] [VOL_REF] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/popp.json
+++ b/descriptors/fsl/popp.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0",
+  "tool-version": "6.0.5",
   "name": "popp",
   "author": "University of Oxford (Mark Jenkinson)",
   "descriptor-url": "http://example.com/popp_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Popp",
   "command-line": "popp [INPUT_FILE] [OUTPUT_BASENAME] [SAMPLING_RATE] [TR_VALUE] [RESP_COLUMN] [CARDIAC_COLUMN] [TRIGGER_COLUMN] [RVT_FLAG] [HEART_RATE_FLAG] [PULSEOX_TRIGGER_FLAG] [SMOOTH_CARD] [SMOOTH_RESP] [HIGH_FREQ_CUTOFF] [LOW_FREQ_CUTOFF] [INIT_THRESH_C] [N_THRESH_C] [INIT_THRESH_R] [N_THRESH_R] [INVERT_RESP_FLAG] [INVERT_CARDIAC_FLAG] [NO_CLEAN_1_FLAG] [NO_CLEAN_2_FLAG] [LOAD_CARD_PHASE] [LOAD_RESP_PHASE] [VOL_FILE] [START_SAMPLE] [RESP_ADD] [RESP_DEL] [CARD_ADD] [CARD_DEL] [VERBOSE_FLAG] [DEBUG_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/possum.json
+++ b/descriptors/fsl/possum.json
@@ -3,14 +3,13 @@
   "name": "possum",
   "description": "Positron emission tomography (PET) simulation tool as part of FSL suite",
   "schema-version": "0.5",
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "author": "University of Oxford (Ivana Drobnjak)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/POSSUM",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/POSSUM",
   "container-image": {
-    "type": "docker",
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/possum_interpmot.py.json
+++ b/descriptors/fsl/possum_interpmot.py.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "possum_interpmot",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Position Interpolation for Movers and Shakers",
   "url": "https://fsl.fmrib.ox.ac.uk",
   "command-line": "/usr/local/fsl/bin/possum_interpmot.py [MOTION_TYPE] [TR] [TR_SLICE] [NSLICES] [NVOLS] [CUSTOM_MOTION_FILE] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/possum_matrix.json
+++ b/descriptors/fsl/possum_matrix.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "2.0",
+  "tool-version": "6.0.5",
   "name": "possum_matrix",
   "author": "University of Oxford (Ivana Drobnjak)",
   "descriptor-url": "https://example.com/path/to/possum_matrix_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/POSSUM",
   "command-line": "possum_matrix -p [PULSE_SEQUENCE] -m [MOTION_MATRIX] -o [OUTPUT_MATRIX] [VERBOSE_FLAG] [HELP_FLAG] [OLD_VERSION_FLAG] [SEGMENT_SIZE]",
   "container-image": {
-    "image": "fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/possum_plot.py.json
+++ b/descriptors/fsl/possum_plot.py.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "possum_plot",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_possum_plot.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/POSSUM",
   "command-line": "/usr/local/fsl/bin/possum_plot.py [INPUT_FILE] [OUTPUT_BASENAME]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/possum_sum.json
+++ b/descriptors/fsl/possum_sum.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "possum_sum",
   "author": "Ivana Drobnjak, University of Oxford",
   "description": "Sum of output signals from multiple possum processors",
   "command-line": "possum_sum [INPUT_SIGNAL] [OUTPUT_SIGNAL] [NUM_PROCESSORS] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/prelude.json
+++ b/descriptors/fsl/prelude.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PRELUDE",
   "command-line": "prelude [1 or more] [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/prepare_fieldmap.json
+++ b/descriptors/fsl/prepare_fieldmap.json
@@ -75,10 +75,10 @@
       "description": "Output name for prepared fieldmap."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/prewhiten.json
+++ b/descriptors/fsl/prewhiten.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "prewhiten",
   "command-line": "prewhiten [FEAT_DIRECTORY] [OUTPUT_DIRECTORY]",
   "description": "Prewhitening tool for FEAT directories",

--- a/descriptors/fsl/probtrackx.json
+++ b/descriptors/fsl/probtrackx.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "probtrackx",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide/",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT",
   "command-line": "probtrackx [SAMPLES] [MASK] [SEED] [OUT] [VERBOSE] [TARGETMASKS] [MASK2] [WAYPOINTS] [NETWORK] [MESH] [SEEDREF] [DIR] [FORCEDIR] [OPD] [PD] [OS2T] [AVOID] [STOP] [XFM] [INVXFM] [NSAMPLES] [NSTEPS] [DISTTHRESH] [CTHR] [FIBTHRESH] [SAMPVOX] [STEPLENGTH] [LOOPCHECK] [USEF] [RANDFIB] [FIBST] [MODEULER] [RSEED] [S2TASTTEXT]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/proj_thresh.json
+++ b/descriptors/fsl/proj_thresh.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "proj_thresh",
   "author": "Unknown",
   "description": "A tool to apply a threshold to either volumes or surfaces.",

--- a/descriptors/fsl/ptoz.json
+++ b/descriptors/fsl/ptoz.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "ptoz",
   "author": "Statistical Parametric Mapping (SPM)",
   "description": "Convert p-values to z-values",
   "command-line": "ptoz [P_VALUE] [TAIL_FLAG] [GRF_FLAG]",
   "container-image": {
-    "image": "spm/spm12:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/pulse.json
+++ b/descriptors/fsl/pulse.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Pulse",
   "command-line": "pulse -i [INPUT_FILE] -o [OUTPUT_BASE] [SEQ] [ANGLE] [TE] [TR] [TRSLC] [NX] [NY] [DX] [DY] [MAXG] [RISET] [BW] [NUMVOL] [NUMSLC] [SLCTHK] [GAP] [ZSTART] [SLCDIR] [PHASEDIR] [READDIR] [VERBOSE_FLAG] [KCOORD_FLAG] [COVER]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/pvmfit.json
+++ b/descriptors/fsl/pvmfit.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "pvmfit",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Fits diffusion models to multishell DWI data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "pvmfit -k [DATA_FILE] -m [MASK_FILE] -r [BVEC_FILE] -b [BVAL_FILE] [OUTPUT_BASENAME] [NUMBER_OF_FIBRES] [MODEL_TYPE] [FIT_ALL_MODELS] [CONSTRAINED_NONLINEAR] [CONSTRAINED_NONLINEAR_F] [GRID_SEARCH] [INCLUDE_NOISE_FLOOR] [SAVE_BIC] [VERBOSE] [HELP]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/qboot.json
+++ b/descriptors/fsl/qboot.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "qboot",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool for computing q-ball ODFs using bootstrap samples",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "qboot [DATA_FILE] [MASK_FILE] [BVECS] [BVALS] [LOGDIR] [FORCEDIR_FLAG] [Q_FILE] [MODEL] [LMAX] [NPEAKS] [THR] [NSAMPLES] [LAMBDA] [DELTA] [ALPHA] [SEED] [GFA_FLAG] [SAVECOEFF_FLAG] [SAVEMEANCOEFF_FLAG] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/randomise.json
+++ b/descriptors/fsl/randomise.json
@@ -315,10 +315,10 @@
       "list": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/rmsdiff.json
+++ b/descriptors/fsl/rmsdiff.json
@@ -1,11 +1,10 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "rmsdiff",
   "description": "Outputs RMS deviation between matrices (in mm)",
   "command-line": "rmsdiff [MATRIXFILE1] [MATRIXFILE2] [REFVOL] [MASK]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/robust_fov.json
+++ b/descriptors/fsl/robust_fov.json
@@ -67,10 +67,10 @@
       "description": "Transformation matrix in_file to out_roi output name."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/robustfov.json
+++ b/descriptors/fsl/robustfov.json
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/robustfov",
   "command-line": "robustfov [OPTIONS] -i [INPUT_FILE] [-r OUTPUT_IMAGE]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/roi.json
+++ b/descriptors/fsl/roi.json
@@ -103,10 +103,10 @@
       "description": "Output ROI file."
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/run_first.json
+++ b/descriptors/fsl/run_first.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "run_first",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "A tool to run FSL's FIRST for subcortical segmentation",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FIRST",
   "command-line": "run_first -i [INPUT_IMAGE] -t [TRANSFORMATION_MATRIX] -n [N_MODES] -o [OUTPUT_BASENAME] -m [MODEL_NAME] [VERBOSE] [INTREF] [LOADBVARS] [MULTIPLE_IMAGES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/run_first_all.json
+++ b/descriptors/fsl/run_first_all.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "run_first_all",
   "author": "FMRIB Software Library (FSL)",
   "description": "FIRST - FMRIB's Integrated Registration and Segmentation Tool for subcortical brain structures",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FIRST",
   "command-line": "run_first_all [METHOD] [BRAINEXTRACT_FLAG] [STRUCTURE] [AFFINE_MATRIX] [THREESTAGE_FLAG] [DEBUG_FLAG] [VERBOSE_FLAG] -i [INPUT_IMAGE] -o [OUTPUT_IMAGE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/run_mesh_utils.json
+++ b/descriptors/fsl/run_mesh_utils.json
@@ -5,8 +5,7 @@
   "description": "A tool for various mesh operations as part of FSL.",
   "command-line": "run_mesh_utils [BASE_MESH] [OUTPUT_IMAGE] [INPUT_IMAGE] [SECOND_INPUT_IMAGE] [WEIGHTING_IMAGE_FORCE] [OPTIONAL_PARAMS...]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/siena.json
+++ b/descriptors/fsl/siena.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "siena",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://example.com/siena_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SIENA",
   "command-line": "siena [INPUT1] [INPUT2] [OUTPUT_DIR] [DEBUG_FLAG] [BETOPTS] [TWO_CLASS_SEG_FLAG] [T2_WEIGHTED_FLAG] [STANDARD_SPACE_MASK_FLAG] [UPPER_IGNORE] [LOWER_IGNORE] [SIENADIFFOPTS] [VENTRICLE_ANALYSIS_FLAG] [VENTRICLE_MASK]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/siena_cal.json
+++ b/descriptors/fsl/siena_cal.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "siena_cal",
   "description": "SIENA is part of FSL (FMRIB Software Library), which performs a two-timepoint brain volume change analysis.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SIENA",

--- a/descriptors/fsl/siena_diff.json
+++ b/descriptors/fsl/siena_diff.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "siena_diff",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "SIENA_diff: Analysis of longitudinal brain image differences.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SIENA",
   "command-line": "siena_diff [INPUT1_BASENAME] [INPUT2_BASENAME] [DEBUG_FLAG] [NO_SEG_FLAG] [SELF_CORR_FACT] [IGNORE_Z_FLOW_FLAG] [APPLY_STD_MASK_FLAG] [SEGMENT_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/siena_flirt.json
+++ b/descriptors/fsl/siena_flirt.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "siena_flirt",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Wrapper for FLIRT image registration within the SIENA framework.",
   "command-line": "siena_flirt [INPUT1_FILEROOT] [INPUT2_FILEROOT]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/siena_flow2std.json
+++ b/descriptors/fsl/siena_flow2std.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "siena_flow2std",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Convert edge flow to standard space",

--- a/descriptors/fsl/sienax.json
+++ b/descriptors/fsl/sienax.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "sienax",
   "author": "FMRIB Centre, University of Oxford",
   "description": "A tool to estimate brain tissue volume from a single MR image and to compare it to an external standard.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SIENA/SienaX",
   "command-line": "sienax [INPUT_FILE] [OUTPUT_DIR] [DEBUG_FLAG] [BET_OPTIONS] [TWOCLASS_SEGMENT] [T2FLAG] [TOP_THRESHOLD] [BOTTOM_THRESHOLD] [REGIONAL_FLAG] [LESION_MASK] [FAST_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/sigloss.json
+++ b/descriptors/fsl/sigloss.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/sigloss",
   "command-line": "sigloss [INPUT_B0MAP] [OUTPUT_SIGLOSS] [MASK] [ECHO_TIME] [SLICE_DIRECTION] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/signal2image.json
+++ b/descriptors/fsl/signal2image.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "signal2image [PULSE_SEQUENCE] [INPUT_SIGNAL] [OUTPUT_IMAGE] [KSPACE_COORDINATES] [OUTPUT_KSPACE] [ABS_FLAG] [HOMODYNE_FLAG] [VERBOSE_FLAG] [APODIZE_FLAG] [CUTOFF] [ROLLOFF] [SAVE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/slice.json
+++ b/descriptors/fsl/slice.json
@@ -40,10 +40,10 @@
       "list": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/sliceanimate.json
+++ b/descriptors/fsl/sliceanimate.json
@@ -1,11 +1,11 @@
 {
-  "tool-version": "3.04",
+  "tool-version": "6.0.5",
   "name": "sliceanimate",
   "author": "Various Authors (Hans Dinsen-Hansen, Kevin Kadow, Mark Podlipec)",
   "description": "A tool for animating slices of an image using whirlgif",
   "command-line": "sliceanimate [OUTPUT_FILE] -- [INPUT_FILES]",
   "container-image": {
-    "image": "custom/sliceanimate:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/slicer.json
+++ b/descriptors/fsl/slicer.json
@@ -299,10 +299,10 @@
       "one-is-required": false
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/slices.json
+++ b/descriptors/fsl/slices.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "slices",
   "author": "Unknown",
   "description": "Generate a set of slices from an image, possibly with some scaling and intensity range options, and save as a GIF.",

--- a/descriptors/fsl/slices_summary.json
+++ b/descriptors/fsl/slices_summary.json
@@ -1,11 +1,10 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "slices_summary",
   "description": "Generate summary PNG images for 4D neuroimaging data.",
   "command-line": "slices_summary [4D_INPUT_FILE] [THRESHOLD] [BACKGROUND_IMAGE] [PICTURES_SUM] [SINGLE_SLICE_FLAG] [DARKER_BACKGROUND_FLAG] [DUMB_RULE_FLAG] | slices_summary [PICTURES_SUM] [OUTPUT_PNG] [TIMEPOINTS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/slicesdir.json
+++ b/descriptors/fsl/slicesdir.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "slicesdir",
   "author": "FMRIB Centre, University of Oxford",
   "description": "slicesdir generates a directory containing orthogonal slices through a set of images.",

--- a/descriptors/fsl/slicesmask.json
+++ b/descriptors/fsl/slicesmask.json
@@ -1,11 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "slicesmask",
   "author": "Unknown",
   "description": "Tool for masking slices from an image using a mask",
   "command-line": "slicesmask [IMAGE] [MASK] [OUTPUT]",
   "container-image": {
-    "image": "unknown",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/slicetimer.json
+++ b/descriptors/fsl/slicetimer.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "slicetimer",
   "author": "University of Oxford, FMRIB",
   "descriptor-url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Slicetimer",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Slicetimer",
   "command-line": "slicetimer -i [INPUT_FILE] [-o OUTPUT_FILE] [--down] [-r TR_VALUE] [-d DIRECTION] [--odd] [--tcustom TCUSTOM_FILE] [--tglobal TGLOBAL_VALUE] [--ocustom OCUSTOM_FILE] [-v]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/smooth_estimate.json
+++ b/descriptors/fsl/smooth_estimate.json
@@ -77,10 +77,10 @@
       "all-or-none": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/smoothest.json
+++ b/descriptors/fsl/smoothest.json
@@ -6,8 +6,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Smoothest",
   "command-line": "smoothest [DEGREES_OF_FREEDOM] [RES_FILE] [ZSTAT_FILE] [MASK] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/spharm_rm.json
+++ b/descriptors/fsl/spharm_rm.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "spharm_rm",
   "author": "University of Oxford (Mark Jenkinson)",
   "description": "Part of FSL - Spherical harmonics removal tool to process neuroimaging data",
   "command-line": "spharm_rm [INPUT_FILE] [OUTPUT_FILE] [MASK_FILE] [NUMBER_OF_TERMS] [VERBOSE_FLAG]",
   "container-image": {
-    "type": "docker",
-    "index": "index.docker.io",
-    "image": "mcin/docker-fsl:6.0.5"
+    "image": "mcin/fsl:6.0.5",
+    "type": "docker"
   },
   "inputs": [
     {

--- a/descriptors/fsl/split.json
+++ b/descriptors/fsl/split.json
@@ -43,10 +43,10 @@
       "optional": false
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/split_parts_gpu.json
+++ b/descriptors/fsl/split_parts_gpu.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "split_parts_gpu",
   "author": "Unknown",
   "description": "Splits parts of data for GPU processing",
   "command-line": "split_parts_gpu [DATAFILE] [MASKFILE] [BVALS_FILE] [BEVCS_FILE] [GRAD_FILE] [USE_GRAD_FILE] [TOTAL_NUM_PARTS] [OUTPUT_DIRECTORY]",
   "container-image": {
-    "image": "some/docker-repo:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/standard_space_roi.json
+++ b/descriptors/fsl/standard_space_roi.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "standard_space_roi",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Masks input and/or reduces its FOV based on a standard space image or mask, transformed into the space of the input image.",
   "command-line": "standard_space_roi [INPUT_FILE] [OUTPUT_FILE] [MASK_FOV_FLAG] [MASK_MASK] [MASK_NONE_FLAG] [ROI_FOV_FLAG] [ROI_MASK] [ROI_NONE_FLAG] [SS_REF] [ALT_INPUT] [DEBUG_FLAG] [BET_PREMASK_FLAG] [FLIRT_OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/std2imgcoord.json
+++ b/descriptors/fsl/std2imgcoord.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "std2imgcoord",
   "author": "FMRIB Centre",
   "description": "Convert standard space coordinates to image space coordinates",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "command-line": "std2imgcoord [OPTIONS] <FILENAME_COORDINATES>",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/surf2surf.json
+++ b/descriptors/fsl/surf2surf.json
@@ -5,8 +5,7 @@
   "description": "Conversions between surface formats and/or conventions",
   "command-line": "surf2surf -i [INPUT_SURFACE] -o [OUTPUT_SURFACE] [INPUT_CONVENTION] [OUTPUT_CONVENTION] [INPUT_REF_VOLUME] [OUTPUT_REF_VOLUME] [TRANSFORM] [OUTPUT_TYPE] [OUTPUT_VALUES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/surface_fdr.json
+++ b/descriptors/fsl/surface_fdr.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "surface_fdr",
   "author": "Unknown",
   "description": "Tool to calculate surface FDR correction for vertex analysis.",

--- a/descriptors/fsl/surfmaths.json
+++ b/descriptors/fsl/surfmaths.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "surfmaths",
   "description": "A command-line tool for performing various mathematical operations on surface files.",
   "command-line": "surfmaths [FIRST_INPUT] [OPERATIONS_INPUTS] [OUTPUT]",

--- a/descriptors/fsl/susan.json
+++ b/descriptors/fsl/susan.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "susan",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Non-linear noise reduction filtering tool",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SUSAN",
   "command-line": "susan [INPUT_FILE] [BT] [DT] [DIM] [USE_MEDIAN] [N_USANS] [USAN1] [BT1] [USAN2] [BT2] [OUTPUT_FILE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/svs_segment.json
+++ b/descriptors/fsl/svs_segment.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "svs_segment",
   "author": "FSL Development Team",
   "description": "FSL Magnetic Resonance Spectroscopy tool to construct mask in T1 space of an SVS voxel and generate a tissue segmentation file.",
   "command-line": "svs_segment [SVS] [T1] [ANAT] [OUTPUT] [FILENAME] [MASK_ONLY_FLAG] [NO_CLEAN_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/swap_dimensions.json
+++ b/descriptors/fsl/swap_dimensions.json
@@ -117,10 +117,10 @@
       "one-is-required": true
     }
   ],
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "schema-version": "0.5",
   "container-image": {
-    "image": "fcpindi/c-pac:latest",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "tags": {

--- a/descriptors/fsl/swap_subjectwise.json
+++ b/descriptors/fsl/swap_subjectwise.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "swap_subjectwise",
   "author": "FMRIB Analysis Group, University of Oxford",
   "description": "Reordering of the dyadic vectors and fsamples according to average inter-subject modal orientations",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "swap_subjectwise [ListOfListOfDyads] [ListOfListOfFsamples] [MASK] [OBASENAME] [XTHRESH] [AVERAGEONLY] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/swap_voxelwise.json
+++ b/descriptors/fsl/swap_voxelwise.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "swap_voxelwise",
   "author": "FMRIB Software Library (FSL)",
   "descriptor-url": "https://example.com/swap_voxelwise_descriptor.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT",
   "command-line": "swap_voxelwise -v [VECTORS_FILE_LIST] -s [SCALARS_FILE_LIST] -m [MASK] -b [OUTPUT_BASE_NAME] --mode [REORDER_MODE] --initmask [INIT_MASK] --xthresh [CROSSING_THRESH] -V",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/swe.json
+++ b/descriptors/fsl/swe.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.3",
+  "tool-version": "6.0.5",
   "name": "swe",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://example.com/descriptors/fsl_swe.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/",
   "command-line": "swe -i [INPUT_FILE] -o [OUTPUT_ROOT] -d [DESIGN_MAT] -t [DESIGN_CON] -s [DESIGN_SUB] [MASK] [FCON] [MODIFIED] [WB] [LOGP] [NBOOT] [CORRP] [FONLY] [TFCE] [TFCE2] [CLUSTER_T] [CLUSTER_T_MASS] [CLUSTER_F] [CLUSTER_F_MASS] [QUIET] [RAW] [EQUIV] [DOF] [UNCORR_P] [NULL_DIST] [NO_RC_MASK] [SEED] [TFCE_HEIGHT] [TFCE_DELTA] [TFCE_EXTENT] [TFCE_CONN] [VOXELWISE_EV] [VOXELWISE_EVS] [GLM_OUTPUT]",
   "container-image": {
-    "image": "fsl/swe:1.0.3",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/systemnoise.json
+++ b/descriptors/fsl/systemnoise.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "systemnoise",
   "author": "University of Oxford (Mark Jenkinson)",
   "descriptor-url": "https://example.com/descriptors/systemnoise.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SystemNoise",
   "command-line": "systemnoise [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_1_preproc.json
+++ b/descriptors/fsl/tbss_1_preproc.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_1_preproc",
   "author": "FSL (FMRIB Software Library)",
   "description": "TBSS (Tract-Based Spatial Statistics) - Step 1: Preprocessing",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS",
   "command-line": "tbss_1_preproc [IMAGES]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_2_reg.json
+++ b/descriptors/fsl/tbss_2_reg.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_2_reg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "TBSS utility for target selection and registration for Tract-Based Spatial Statistics (TBSS) analysis",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS/UserGuide",
   "command-line": "tbss_2_reg [TARGET_SELECTION_OPTION]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_3_postreg.json
+++ b/descriptors/fsl/tbss_3_postreg.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_3_postreg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_tbss_3_postreg.json",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS/UserGuide#tbss_3_postreg",
   "command-line": "tbss_3_postreg [OPTIONS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_4_prestats.json
+++ b/descriptors/fsl/tbss_4_prestats.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_4_prestats",
   "author": "FMRIB Software Library",
   "description": "A tool for thresholding the Mean FA Skeleton in TBSS analysis",

--- a/descriptors/fsl/tbss_deproject.json
+++ b/descriptors/fsl/tbss_deproject.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_deproject",
   "description": "Tool to deproject images from skeleton space to final space",
   "command-line": "tbss_deproject [SKELETON_SPACE_INPUT_IMAGE] [FINAL_SPACE] [INDEX_IMAGE_FLAG]",

--- a/descriptors/fsl/tbss_fill.json
+++ b/descriptors/fsl/tbss_fill.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_fill",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Tool for filling skeletonized FA images in TBSS",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS",
   "command-line": "tbss_fill [STATS_IMAGE] [THRESHOLD] [MEAN_FA] [OUTPUT] [INCLUDE_NEGATIVE_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_non_FA.json
+++ b/descriptors/fsl/tbss_non_FA.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_non_FA",
   "author": "FMRIB, Oxford Centre for Functional MRI of the Brain",
   "description": "TBSS processing for non-FA images",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS/UserGuide",
   "command-line": "fslmerge [CONCATENATION_OPTION] [OUTPUT_FILE] [INPUT_FILES] [TR_VALUE] [VOLUME_NUMBER]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_skeleton.json
+++ b/descriptors/fsl/tbss_skeleton.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.03",
+  "tool-version": "6.0.5",
   "name": "tbss_skeleton",
   "author": "University of Oxford (Stephen Smith)",
   "descriptor-url": "https://www.fmrib.ox.ac.uk/fsl",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS",
   "command-line": "tbss_skeleton [INPUT_IMAGE] [OUTPUT_IMAGE] [SKEL_THRESH] [DISTANCEMAP] [SEARCH_RULE_MASK] [DATA_4D] [PROJECTED_4D] [ALT_4D] [ALT_SKELETON] [DEBUG_FLAG] [SKEL_POINTS]",
   "container-image": {
-    "image": "mcin/docker-fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_sym.json
+++ b/descriptors/fsl/tbss_sym.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.03",
+  "tool-version": "6.0.5",
   "name": "tbss_skeleton",
   "author": "University of Oxford (Stephen Smith)",
   "descriptor-url": "https://github.com/fsl/fsl/blob/master/doc/fsl/tbss_skeleton.txt",
@@ -7,8 +7,7 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS/UserGuide#Step_4:_tbss_skeleton",
   "command-line": "tbss_skeleton [INPUT_IMAGE] [SKEL_THRESHOLD] [DISTANCE_MAP] [SEARCH_RULE_MASK] [4DDATA] [PROJECTED_4DDATA] [ALT_4DDATA] [ALT_SKELETON] [OUTPUT_IMAGE] [HELP_FLAG] [DEBUG_FLAG] [SKELPOINTS]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tbss_x.json
+++ b/descriptors/fsl/tbss_x.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tbss_x",
   "author": "FMRIB Software Library (FSL)",
   "description": "TBSS cross-subject script for processing scalar and vector directories.",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/TBSS",
   "command-line": "tbss_x [SCALAR_DIRS] [VECTOR_DIRS]",
   "container-image": {
-    "image": "fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tcalc.json
+++ b/descriptors/fsl/tcalc.json
@@ -5,8 +5,7 @@
   "description": "Resample a 4D phantom for theoretical calculations",
   "command-line": "resample -i [INPUT_IMAGE] -o [OUTPUT_IMAGE] [ECHO_TIME] [REPETITION_TIME] [MRPAR_FILE] [NUM_VOXEL_X] [NUM_VOXEL_Y] [NUM_VOXEL_Z] [VOXEL_SIZE_X] [VOXEL_SIZE_Y] [VOXEL_SIZE_Z] [START_POSITION] [NOISE_SIGMA] [SAVE_FLAG] [VERBOSE_FLAG]",
   "container-image": {
-    "image": "fsl:6.0.5",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/topup.json
+++ b/descriptors/fsl/topup.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "build 509",
+  "tool-version": "6.0.5",
   "name": "topup",
   "author": "University of Oxford",
   "description": "topup is part of FSL and is used to estimate and correct for susceptibility-induced distortions in echo planar imaging (EPI) data.",
   "command-line": "topup [IMAIN] [DATAIN] [OUT] [FOUT] [IOUT] [LOGOUT] [WARPres] [SUBSAMP] [FWHM] [CONFIG] [MITER] [LAMBDA] [SSQLAMBDA] [REGMOD] [ESTMOV] [MINMET] [SPLINEORDER] [NUMPREC] [INTERP] [SCALE] [REGRID] [VERBOSE]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/tsplot.json
+++ b/descriptors/fsl/tsplot.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "tsplot",
   "author": "FMRIB",
   "description": "Time series plotting tool for FSL",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/tsplot",
   "command-line": "tsplot [INPUT_DIRECTORY] [MAIN_FILTERED_DATA] [COORDINATES] [COORDINATES_OUTPUT] [MASK] [OUTPUT_DIRECTORY] [NO_WEIGHT_FLAG] [PREWHITEN_FLAG] [NO_RAW_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/ttologp.json
+++ b/descriptors/fsl/ttologp.json
@@ -1,12 +1,11 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "ttologp",
   "author": "Unknown",
   "description": "Tool for computing logp",
   "command-line": "ttologp [OPTIONS] [VARSFILE] [CBSFILE] [DOF]",
   "container-image": {
-    "image": "some-docker-repo/ttologp:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/ttoz.json
+++ b/descriptors/fsl/ttoz.json
@@ -1,11 +1,10 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "ttoz",
   "description": "Tool to convert a T-statistic image to a Z-statistic image",
   "command-line": "ttoz [OPTIONS] <varsfile> <cbsfile> <dof>",
   "container-image": {
-    "image": "your-docker-image:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/unconfound.json
+++ b/descriptors/fsl/unconfound.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "unconfound",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Removing confounds from 4D fMRI data",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL",
   "command-line": "unconfound [IN4D] [OUT4D] [CONFOUND_MAT]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/vecreg.json
+++ b/descriptors/fsl/vecreg.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "vecreg",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Vector Affine/NonLinear Transformation with Orientation Preservation",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
   "command-line": "vecreg [INPUT_FILE] [OUTPUT_FILE] [REF_VOL] [TRANSFORM_FILE] [VERBOSE_FLAG] [HELP_FLAG] [SECONDARY_AFFINE] [SECONDARY_WARP] [INTERP_METHOD] [BRAIN_MASK] [REF_BRAIN_MASK]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/viena_quant.json
+++ b/descriptors/fsl/viena_quant.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "viena_quant",
   "author": "Unknown",
   "description": "Automated brain ventricle quantification tool",

--- a/descriptors/fsl/whirlgif.json
+++ b/descriptors/fsl/whirlgif.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "3.04",
+  "tool-version": "6.0.5",
   "name": "whirlgif",
   "author": "Hans Dinsen-Hansen, Kevin Kadow, Mark Podlipec",
   "description": "GIF animation tool",

--- a/descriptors/fsl/wpng.json
+++ b/descriptors/fsl/wpng.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.03",
+  "tool-version": "6.0.5",
   "name": "wpng",
   "author": "Unknown",
   "description": "Simple PGM/PPM/PAM to PNG Converter",

--- a/descriptors/fsl/xfibres.json
+++ b/descriptors/fsl/xfibres.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "6.0.5:9e026117",
+  "tool-version": "6.0.5",
   "name": "xfibres",
   "author": "FMRIB Centre, University of Oxford",
   "description": "Part of FSL - estimates diffusion parameters for multiple fibres per voxel",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide",
   "command-line": "xfibres [DATA_FILE] [MASK_FILE] [BVECS_FILE] [BVALS_FILE] [LOG_DIR] [FORCEDIR_FLAG] [MAX_FIBRES] [MODEL] [FUDGE] [NUM_JUMPS] [NUM_BURNIN] [BURNIN_NO_AR] [NUM_SAMPLE_EVERY] [NUM_UPDATE_PROPOSAL_EVERY] [SEED] [NO_ARD] [ALL_ARD] [NO_SPAT] [NONLINEAR] [CONSTRAINED_NONLINEAR] [RICIAN] [ADD_F0] [ARD_F0] [R_MEAN] [R_STD] [VERBOSE_FLAG] [HELP_FLAG]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/xtract_blueprint.json
+++ b/descriptors/fsl/xtract_blueprint.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "xtract_blueprint",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Blueprint extraction tool using XTRACT and bedpostx folders",

--- a/descriptors/fsl/xtract_stats.json
+++ b/descriptors/fsl/xtract_stats.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "xtract_stats",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "description": "Quantitative evaluation tool of XTRACT results in neuroimaging",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/",
   "command-line": "xtract_stats -d <folder_basename> -xtract <XTRACT_dir> -w <xtract2diff> [reference] [output_file] [structures_file] [threshold] [measurements] [keep_temp_files]",
   "container-image": {
-    "image": "mcin/docker-fsl:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/xtract_viewer.json
+++ b/descriptors/fsl/xtract_viewer.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "xtract_viewer",
   "author": "FMRIB Centre, University of Oxford",
   "description": "Viewer tool for XTRACT output",

--- a/descriptors/fsl/zeropad.json
+++ b/descriptors/fsl/zeropad.json
@@ -1,13 +1,12 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "zeropad",
   "author": "Unknown",
   "description": "Tool for zero-padding numbers to a specified length",
   "url": "Unknown",
   "command-line": "zeropad [INPUT_NUMBER] [LENGTH]",
   "container-image": {
-    "image": "zeropad:latest",
-    "index": "index.docker.io",
+    "image": "mcin/fsl:6.0.5",
     "type": "docker"
   },
   "inputs": [

--- a/descriptors/fsl/ztop.json
+++ b/descriptors/fsl/ztop.json
@@ -1,5 +1,5 @@
 {
-  "tool-version": "1.0.0",
+  "tool-version": "6.0.5",
   "name": "ztop",
   "description": "Converts a z-score to a p-value.",
   "command-line": "ztop [Z_SCORE] [TAIL_FLAG] [GRF_FLAG] [NUMBER_OF_RESELS]",


### PR DESCRIPTION
Updates the following tools docker images to a single source (partially addresses #118):

* ants: `antsx/ants:2.5.3`
* c3d: `pyushkevich/itksnap:3.8.2` (c3d version 1.1.0)
* fsl: `mcin/fsl:6.0.5`

All but fsl is from maintainers / first-party - can change as needed.