### PR TITLE
Add list-seperator to fsl applytopup

### DIFF
--- a/descriptors/fsl/applytopup.json
+++ b/descriptors/fsl/applytopup.json
@@ -16,6 +16,7 @@
       "value-key": "[IMAIN]",
       "type": "String",
       "list": true,
+      "list-separator": ",",
       "optional": false,
       "id": "imain",
       "name": "Input images"
@@ -37,6 +38,7 @@
       "value-key": "[ININDEX]",
       "type": "String",
       "list": true,
+      "list-separator": ",",
       "optional": false,
       "id": "inindex",
       "name": "Input index"


### PR DESCRIPTION
Add list sepearator to list arguments for applytopup - was causing this command to not compile.