### PR TITLE
Update topup / applytopup flags

### DIFF
--- a/descriptors/fsl/applytopup.json
+++ b/descriptors/fsl/applytopup.json
@@ -48,10 +48,10 @@
       "command-line-flag-separator": "=",
       "description": "Name of field/movements (from topup)",
       "value-key": "[TOPUP]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "topup",
-      "name": "Topup file"
+      "name": "Topup prefix"
     },
     {
       "command-line-flag": "--out",

--- a/descriptors/fsl/topup.json
+++ b/descriptors/fsl/topup.json
@@ -3,7 +3,7 @@
   "name": "topup",
   "author": "University of Oxford",
   "description": "topup is part of FSL and is used to estimate and correct for susceptibility-induced distortions in echo planar imaging (EPI) data.",
-  "command-line": "topup [IMAIN] [DATAIN] [OUT] [FOUT] [IOUT] [LOGOUT] [WARPres] [SUBSAMP] [FWHM] [CONFIG] [MITER] [LAMBDA] [SSQLAMBDA] [REGMOD] [ESTMOV] [MINMET] [SPLINEORDER] [NUMPREC] [INTERP] [SCALE] [REGRID] [VERBOSE]",
+  "command-line": "topup [IMAIN] [DATAIN] [OUT] [FOUT] [IOUT] [LOGOUT] [WARPres] [SUBSAMP] [FWHM] [CONFIG] [MITER] [LAMBDA] [SSQLAMBDA] [REGMOD] [ESTMOV] [MINMET] [SPLINEORDER] [NUMPREC] [INTERP] [SCALE] [REGRID] [NTHR] [VERBOSE]",
   "container-image": {
     "image": "mcin/fsl:6.0.5",
     "type": "docker"
@@ -221,6 +221,16 @@
       "optional": true,
       "id": "regrid",
       "name": "Regrid calculations"
+    },
+    {
+      "command-line-flag": "--nthr",
+      "command-line-flag-separator": "=",
+      "description": "Number of threads to use (cannot be greater than numbers of hardware cores), default 1",
+      "value-key": "[NTHR]",
+      "type": "Number",
+      "optional": true,
+      "id": "nthr",
+      "name": "Number of threads"
     },
     {
       "command-line-flag": "--verbose",


### PR DESCRIPTION
This PR:

1. Adds the new `--nthr` flag to topup in FSL 6.0.5
2. Changes the `--topup` flag in `applytopup` from `File` to `String` - this is the prefix used in `topup` and not an actual file.