### PR TITLE
Switch imain to File from String in applytopup

### DIFF
--- a/descriptors/fsl/applytopup.json
+++ b/descriptors/fsl/applytopup.json
@@ -14,7 +14,7 @@
       "command-line-flag-separator": "=",
       "description": "Comma separated list of names of input image (to be corrected)",
       "value-key": "[IMAIN]",
-      "type": "String",
+      "type": "File",
       "list": true,
       "list-separator": ",",
       "optional": false,


### PR DESCRIPTION
One more change - currently `--imain` in `applytopup` is a string, which (I think?) is resulting in the file not being bound when running with a container. This switches it to a `File` type. I'm not sure how the container runners handles bindings for list of containers.