### PR TITLE
Switch dwibiascorrect output type to 'String'

### DIFF
--- a/descriptors/mrtrix/dwibiascorrect.json
+++ b/descriptors/mrtrix/dwibiascorrect.json
@@ -30,7 +30,7 @@
     {
       "id": "output_image",
       "name": "Output Image",
-      "type": "File",
+      "type": "String",
       "value-key": "[OUTPUT_IMAGE]",
       "description": "The output corrected image series",
       "optional": false


### PR DESCRIPTION
Output type as 'File' had containers attempting to bind a non-existent file. This fixes it :football:.