### PR TITLE
Fix mrconvert list-separator for axes arg

### DIFF
--- a/descriptors/mrtrix/mrconvert.json
+++ b/descriptors/mrtrix/mrconvert.json
@@ -82,7 +82,8 @@
       "type": "Number",
       "optional": true,
       "integer": true,
-      "list": true
+      "list": true,
+      "list-separator": ","
     },
     {
       "id": "scaling",


### PR DESCRIPTION
Just adds "," 🐛 