### PR TITLE
Fix mrconvert list-seperator

### DIFF
--- a/descriptors/mrtrix/mrconvert.json
+++ b/descriptors/mrtrix/mrconvert.json
@@ -83,7 +83,7 @@
       "optional": true,
       "integer": true,
       "list": true,
-      "list-separator": ","
+      "list-seperator": ","
     },
     {
       "id": "scaling",

--- a/descriptors/mrtrix/mrconvert.json
+++ b/descriptors/mrtrix/mrconvert.json
@@ -82,7 +82,8 @@
       "type": "Number",
       "optional": true,
       "integer": true,
-      "list": true
+      "list": true,
+      "list-separator": ","
     },
     {
       "id": "scaling",

--- a/extraction/mrtrix/mrt2bt.js
+++ b/extraction/mrtrix/mrt2bt.js
@@ -373,6 +373,9 @@ for (const file of fs.readdirSync(jsonPath)) {
             ]
           };
     }
+    else if (descriptor.name == 'mrconvert') {
+        descriptor.inputs[4]["list-seperator"] = ",";
+    }
 
     console.log(" done");
 


### PR DESCRIPTION
List seperator was removed from auto-generated descriptor (had been previously fixed for 0.1.0). This just adds it back in.