### PR TITLE
Ignore mrtrix gui + cleanup commands

### DIFF
--- a/packages/mrtrix.json
+++ b/packages/mrtrix.json
@@ -233,7 +233,7 @@
       },
       {
         "target": "for_each",
-        "status": "missing"
+        "status": "ignore"
       },
       {
         "target": "label2colour",
@@ -396,11 +396,11 @@
       },
       {
         "target": "mrtrix_cleanup",
-        "status": "missing"
+        "status": "ignore"
       },
       {
         "target": "mrview",
-        "status": "done",
+        "status": "ignore",
         "descriptor": "descriptors/mrtrix/mrview.json"
       },
       {
@@ -459,7 +459,7 @@
       },
       {
         "target": "shview",
-        "status": "done",
+        "status": "ignore",
         "descriptor": "descriptors/mrtrix/shview.json"
       },
       {


### PR DESCRIPTION
This also ignores the two gui commands that are already done, but wouldn't actually be used in a workflow.