### PR TITLE
3dcalc

### DIFF
--- a/descriptors/afni/3dcalc.json
+++ b/descriptors/afni/3dcalc.json
@@ -1,6 +1,6 @@
 {
   "name": "3dcalc",
-  "command-line": "3dcalc [EXPR] [IN_FILE_A] [IN_FILE_B] [IN_FILE_C] [OTHER] [OVERWRITE] [SINGLE_IDX] [START_IDX] [STOP_IDX]",
+  "command-line": "3dcalc  [IN_FILE_A] [IN_FILE_B] [IN_FILE_C] [OTHER] [OVERWRITE] [SINGLE_IDX] [START_IDX] [STOP_IDX] [EXPR] [PREFIX]",
   "author": "AFNI Developers",
   "description": "AFNI's calculator program.",
   "url": "https://afni.nimh.nih.gov/",
@@ -11,7 +11,8 @@
       "type": "String",
       "value-key": "[EXPR]",
       "description": "Expr.",
-      "optional": false
+      "optional": false,
+      "command-line-flag": "-expr"
     },
     {
       "id": "in_file_a",
@@ -74,7 +75,9 @@
       "value-key": "[START_IDX]",
       "description": "Start index for in_file_a.",
       "optional": true,
-      "requires-inputs": ["stop_idx"]
+      "requires-inputs": [
+        "stop_idx"
+      ]
     },
     {
       "id": "stop_idx",
@@ -84,7 +87,18 @@
       "value-key": "[STOP_IDX]",
       "description": "Stop index for in_file_a.",
       "optional": true,
-      "requires-inputs": ["start_idx"]
+      "requires-inputs": [
+        "start_idx"
+      ]
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "String",
+      "value-key": "[PREFIX]",
+      "description": "Output image file name.",
+      "optional": true,
+      "command-line-flag": "-prefix"
     }
   ],
   "output-files": [
@@ -93,9 +107,8 @@
       "id": "out_file",
       "optional": true,
       "description": "Output image file name.",
-      "path-template": "[IN_FILE_A]",
-      "value-key": "[OUT_FILE]",
-      "command-line-flag": "-prefix"
+      "path-template": "[PREFIX]",
+      "value-key": "[PREFIX]"
     }
   ],
   "tool-version": "24.2.06",


### PR DESCRIPTION
arranged the command line args and added prefix.
Tested with CPAC generated command
```
3dcalc -a /ocean/projects/med220004p/bshresth/projects/rbc-runs/output2/working/pipeline_RBCv0/cpac_pipeline_RBCv0_sub-PA001_ses-V1W1/anat_reorient_0/sub-PA001_ses-V1W1_acq-MPR_rec-Norm_T1w_resample.nii.gz -b /ocean/projects/med220004p/bshresth/projects/rbc-runs/output2/working/pipeline_RBCv0/cpac_pipeline_RBCv0_sub-PA001_ses-V1W1/anat_skullstrip_ants/atropos_wf/copy_xform/09_relabel_wm_mask_xform.nii.gz -expr "a*step(b)" -prefix sub-PA001_ses-V1W1_acq-MPR_rec-Norm_T1w_resample_calc.nii.gz
```
