### PR TITLE
3dBlurToFWHM

### DIFF
--- a/descriptors/afni/3dBlurToFWHM.json
+++ b/descriptors/afni/3dBlurToFWHM.json
@@ -1,6 +1,6 @@
 {
   "name": "3dBlurToFWHM",
-  "command-line": "3dBlurToFWHM [AUTOMASK] [BLURMASTER] [FWHM] [FWHMXY] [IN_FILE] [MASK] [OUT_FILE] [OUTPUTTYPE]",
+  "command-line": "3dBlurToFWHM [AUTOMASK] [BLURMASTER] [FWHM] [FWHMXY] [IN_FILE] [MASK] [OUTPUTTYPE] [PREFIX]",
   "author": "AFNI Developers",
   "description": "Blurs a 'master' dataset until it reaches a specified FWHM smoothness (approximately).",
   "url": "https://afni.nimh.nih.gov/",
@@ -66,7 +66,20 @@
       "value-key": "[OUTPUTTYPE]",
       "description": "'nifti' or 'afni' or 'nifti_gz'. Afni output filetype.",
       "optional": true,
-      "value-choices": ["NIFTI", "AFNI", "NIFTI_GZ"]
+      "value-choices": [
+        "NIFTI",
+        "AFNI",
+        "NIFTI_GZ"
+      ]
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "String",
+      "value-key": "[PREFIX]",
+      "command-line-flag": "-prefix",
+      "description": "Prefix for output dataset.",
+      "optional": true
     }
   ],
   "output-files": [
@@ -75,16 +88,8 @@
       "id": "out_file",
       "optional": true,
       "description": "Output image file name.",
-      "path-template": "[IN_FILE]_afni",
-      "value-key": "[OUT_FILE]",
-      "command-line-flag": "-prefix"
-    },
-    {
-      "name": "Out file",
-      "id": "out_file",
-      "path-template": "out_file",
-      "optional": true,
-      "description": "Output file."
+      "path-template": "[PREFIX]",
+      "value-key": "[PREFIX]"
     }
   ],
   "tool-version": "24.2.06",

--- a/descriptors/afni/3dBlurToFWHM.json
+++ b/descriptors/afni/3dBlurToFWHM.json
@@ -97,9 +97,5 @@
   "container-image": {
     "type": "docker",
     "image": "afni/afni_make_build:AFNI_24.2.06"
-  },
-  "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
   }
 }


### PR DESCRIPTION
Tested with CPAC generated command
```
    3dBlurToFWHM -FWHM 6.000000 
    -input /ocean/projects/med220004p/rupprech/ecpac_runs/base_rbc-2/rbc-options/sub-NDARINV2VY7YYNW/wd/pipeline_RBCv0/cpac_sub-NDARINV2VY7YYNW_ses-baselineYear1Arm1/reho_289/_scan_rest_run-01/reho_map/ReHo.nii.gz 
    -mask /ocean/projects/med220004p/rupprech/ecpac_runs/base_rbc-2/rbc-options/sub-NDARINV2VY7YYNW/wd/pipeline_RBCv0/cpac_sub-NDARINV2VY7YYNW_ses-baselineYear1Arm1/_scan_rest_run-01/applyxfm_deriv_mask_to_standard_189/ref_bold_corrected_brain_mask_maths_trans.nii.gz 
    -prefix ReHo_afni.nii.gz
```