### PR TITLE
fslstats

### DIFF
--- a/descriptors/fsl/fslstats.json
+++ b/descriptors/fsl/fslstats.json
@@ -20,7 +20,7 @@
       "name": "Input file"
     },
     {
-      "command-line-flag": "-K",
+      "command-line-flag": "-k",
       "description": "Generate separate n submasks from indexMask, for indexvalues 1..n where n is the maximum index value in indexMask, and generate statistics for each submask",
       "value-key": "[INDEX_MASK]",
       "type": "File",
@@ -268,7 +268,10 @@
     {
       "description": "Preoptions",
       "id": "preoptions_group",
-      "members": ["index_mask", "timeseries_flag"],
+      "members": [
+        "index_mask",
+        "timeseries_flag"
+      ],
       "name": "Preoptions"
     },
     {


### PR DESCRIPTION
Tested with CPAC generated command
```
    fslstats /ocean/projects/med220004p/rupprech/ecpac_runs/base_rbc-2/rbc-options/sub-NDARINV2VY7YYNW/wd/pipeline_RBCv0/cpac_sub-NDARINV2VY7YYNW_ses-baselineYear1Arm1/space-template_lfcdw_smooth_AFNI_303/_scan_rest_run-01/_fwhm_6/smooth/local_functional_connectivity_density_Weighted_afni.nii.gz 
    -k /ocean/projects/med220004p/bshresth/projects/niwrap-dev/cpac_templates/Mask_ABIDE_85Percent_GM.nii.gz 
    -s
```