### PR TITLE
Add dcm2niix package and descriptor Fix #150

### DIFF
--- a/descriptors/dcm2niix/dcm2niix.json
+++ b/descriptors/dcm2niix/dcm2niix.json
@@ -1,0 +1,415 @@
+{
+  "name": "dcm2niix",
+  "tool-version": "v1.0.20240202",
+  "description": "Chris Rorden's dcm2niiX - DICOM to NIfTI converter. Converts DICOM files to NIfTI format with optional BIDS sidecar generation.",
+  "author": "Chris Rorden",
+  "command-line": "dcm2niix [COMPRESSION] [ADJACENT] [BIDS] [BIDS_ANON] [COMMENT] [DEPTH] [EXPORT_FORMAT] [FILENAME] [DEFAULTS] [IGNORE_DERIVED] [SCALING] [MERGE_2D] [SERIES_NUMBER] [OUTPUT_DIR] [PHILIPS_SCALING] [SEARCH_MODE] [RENAME] [SINGLE_FILE] [UPDATE_CHECK] [VERBOSE] [CONFLICT_BEHAVIOR] [CROP_3D] [GZ_COMPRESS] [ENDIAN] [PROGRESS] [IGNORE_TRIGGER] [TERSE] [XML] [INPUT_DIR]",
+  "schema-version": "0.5",
+  "inputs": [
+    {
+      "id": "input_dir",
+      "name": "Input directory",
+      "type": "File",
+      "value-key": "[INPUT_DIR]",
+      "optional": false,
+      "description": "Input folder containing DICOM files. Will be searched recursively based on depth parameter."
+    },
+    {
+      "id": "compression_level",
+      "name": "Compression level",
+      "type": "Number",
+      "value-key": "[COMPRESSION]",
+      "command-line-flag": "-",
+      "command-line-flag-separator": "",
+      "optional": true,
+      "minimum": 1,
+      "maximum": 9,
+      "description": "gz compression level (1=fastest..9=smallest)"
+    },
+    {
+      "id": "adjacent",
+      "name": "Adjacent DICOMs",
+      "type": "String",
+      "value-key": "[ADJACENT]",
+      "command-line-flag": "-a",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Adjacent DICOMs (images from same series always in same folder) for faster conversion"
+    },
+    {
+      "id": "bids",
+      "name": "BIDS sidecar",
+      "type": "String",
+      "value-key": "[BIDS]",
+      "command-line-flag": "-b",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "o"
+      ],
+      "description": "Generate BIDS sidecar JSON files (o=only: no NIfTI)"
+    },
+    {
+      "id": "bids_anon",
+      "name": "Anonymize BIDS",
+      "type": "String",
+      "value-key": "[BIDS_ANON]",
+      "command-line-flag": "-ba",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Anonymize BIDS sidecar files by removing personal information"
+    },
+    {
+      "id": "comment",
+      "name": "Comment",
+      "type": "String",
+      "value-key": "[COMMENT]",
+      "command-line-flag": "-c",
+      "optional": true,
+      "description": "Comment stored in NIfTI aux_file (up to 24 characters)"
+    },
+    {
+      "id": "depth",
+      "name": "Search depth",
+      "type": "Number",
+      "value-key": "[DEPTH]",
+      "command-line-flag": "-d",
+      "optional": true,
+      "minimum": 0,
+      "maximum": 9,
+      "description": "Directory search depth for DICOM files in sub-folders"
+    },
+    {
+      "id": "export_format",
+      "name": "Export format",
+      "type": "String",
+      "value-key": "[EXPORT_FORMAT]",
+      "command-line-flag": "-e",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "o",
+        "j",
+        "b"
+      ],
+      "description": "Export format: NRRD (y), MGH (o), JSON/JNIfTI (j), or BJNIfTI (b)"
+    },
+    {
+      "id": "filename",
+      "name": "Filename template",
+      "type": "String",
+      "value-key": "[FILENAME]",
+      "command-line-flag": "-f",
+      "optional": true,
+      "description": "Output filename template (%a=antenna, %b=basename, %c=comments, %d=description, %e=echo number, %f=folder name, %g=accession number, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %o=mediaObjectInstanceUID, %p=protocol, %r=instance number, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID; %z=sequence name)"
+    },
+    {
+      "id": "defaults",
+      "name": "Generate defaults",
+      "type": "String",
+      "value-key": "[DEFAULTS]",
+      "command-line-flag": "-g",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "o",
+        "i"
+      ],
+      "description": "Generate defaults file (o=only: reset and write defaults; i=ignore: reset defaults)"
+    },
+    {
+      "id": "ignore_derived",
+      "name": "Ignore derived images",
+      "type": "String",
+      "value-key": "[IGNORE_DERIVED]",
+      "command-line-flag": "-i",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Ignore derived, localizer and 2D images"
+    },
+    {
+      "id": "scaling",
+      "name": "Integer scaling",
+      "type": "String",
+      "value-key": "[SCALING]",
+      "command-line-flag": "-l",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "o"
+      ],
+      "description": "Losslessly scale 16-bit integers (y=scale, n=no but uint16->int16, o=original)"
+    },
+    {
+      "id": "merge_2d",
+      "name": "Merge 2D slices",
+      "type": "String",
+      "value-key": "[MERGE_2D]",
+      "command-line-flag": "-m",
+      "optional": true,
+      "value-choices": [
+        "n",
+        "y",
+        "0",
+        "1",
+        "2"
+      ],
+      "description": "Merge 2D slices from same series regardless of echo, exposure, etc. (0=no, 1=yes, 2=auto)"
+    },
+    {
+      "id": "series_number",
+      "name": "Series number",
+      "type": "String",
+      "value-key": "[SERIES_NUMBER]",
+      "command-line-flag": "-n",
+      "optional": true,
+      "description": "Only convert specified series CRC number (can be used up to 16 times)"
+    },
+    {
+      "id": "output_dir",
+      "name": "Output directory",
+      "type": "String",
+      "value-key": "[OUTPUT_DIR]",
+      "command-line-flag": "-o",
+      "optional": true,
+      "description": "Output directory (omit to save to input folder)",
+      "default-value": "."
+    },
+    {
+      "id": "philips_scaling",
+      "name": "Philips scaling",
+      "type": "String",
+      "value-key": "[PHILIPS_SCALING]",
+      "command-line-flag": "-p",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Use Philips precise float (not display) scaling"
+    },
+    {
+      "id": "search_mode",
+      "name": "Search mode",
+      "type": "String",
+      "value-key": "[SEARCH_MODE]",
+      "command-line-flag": "-q",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "l",
+        "n"
+      ],
+      "description": "Search mode (y=show number of DICOMs, l=list DICOMs, n=no)"
+    },
+    {
+      "id": "rename",
+      "name": "Rename only",
+      "type": "String",
+      "value-key": "[RENAME]",
+      "command-line-flag": "-r",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Rename instead of convert DICOMs"
+    },
+    {
+      "id": "single_file",
+      "name": "Single file mode",
+      "type": "String",
+      "value-key": "[SINGLE_FILE]",
+      "command-line-flag": "-s",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Single file mode, do not convert other images in folder"
+    },
+    {
+      "id": "update_check",
+      "name": "Update check",
+      "type": "Flag",
+      "value-key": "[UPDATE_CHECK]",
+      "command-line-flag": "-u",
+      "optional": true,
+      "description": "Check for newer versions"
+    },
+    {
+      "id": "verbose",
+      "name": "Verbose output",
+      "type": "String",
+      "value-key": "[VERBOSE]",
+      "command-line-flag": "-v",
+      "optional": true,
+      "value-choices": [
+        "0",
+        "1",
+        "2"
+      ],
+      "description": "Verbose output (0=no, 1=yes, 2=logorrheic)"
+    },
+    {
+      "id": "conflict_behavior",
+      "name": "Conflict behavior",
+      "type": "Number",
+      "value-key": "[CONFLICT_BEHAVIOR]",
+      "command-line-flag": "-w",
+      "optional": true,
+      "value-choices": [
+        0,
+        1,
+        2
+      ],
+      "description": "Write behavior for name conflicts (0=skip, 1=overwrite, 2=add suffix)"
+    },
+    {
+      "id": "crop_3d",
+      "name": "Crop 3D",
+      "type": "String",
+      "value-key": "[CROP_3D]",
+      "command-line-flag": "-x",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "i"
+      ],
+      "description": "Crop 3D acquisitions (i=ignore: neither crop nor rotate)"
+    },
+    {
+      "id": "compression",
+      "name": "Compression",
+      "type": "String",
+      "value-key": "[GZ_COMPRESS]",
+      "command-line-flag": "-z",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "o",
+        "i",
+        "n",
+        "3"
+      ],
+      "description": "gz compress images (y=pigz, o=optimal pigz, i=internal:zlib, n=no, 3=no,3D)"
+    },
+    {
+      "id": "endian",
+      "name": "Byte order",
+      "type": "String",
+      "value-key": "[ENDIAN]",
+      "command-line-flag": "--big-endian",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n",
+        "o"
+      ],
+      "description": "Byte order (y=big-end, n=little-end, o=optimal/native)"
+    },
+    {
+      "id": "progress",
+      "name": "Progress information",
+      "type": "String",
+      "value-key": "[PROGRESS]",
+      "command-line-flag": "--progress",
+      "optional": true,
+      "value-choices": [
+        "y",
+        "n"
+      ],
+      "description": "Slicer format progress information"
+    },
+    {
+      "id": "ignore_trigger",
+      "name": "Ignore trigger times",
+      "type": "Flag",
+      "value-key": "[IGNORE_TRIGGER]",
+      "command-line-flag": "--ignore_trigger_times",
+      "optional": true,
+      "description": "Disregard values in 0018,1060 and 0020,9153"
+    },
+    {
+      "id": "terse",
+      "name": "Terse output",
+      "type": "Flag",
+      "value-key": "[TERSE]",
+      "command-line-flag": "--terse",
+      "optional": true,
+      "description": "Omit filename post-fixes (can cause overwrites)"
+    },
+    {
+      "id": "xml",
+      "name": "XML output",
+      "type": "Flag",
+      "value-key": "[XML]",
+      "command-line-flag": "--xml",
+      "optional": true,
+      "description": "Output Slicer format features"
+    }
+  ],
+  "groups": [
+    {
+      "id": "output_options",
+      "name": "Output Options",
+      "members": [
+        "compression_level",
+        "export_format",
+        "filename",
+        "output_dir",
+        "compression",
+        "endian"
+      ],
+      "description": "Options controlling output file format and location"
+    },
+    {
+      "id": "bids_options",
+      "name": "BIDS Options",
+      "members": [
+        "bids",
+        "bids_anon"
+      ],
+      "description": "Options related to BIDS sidecar generation"
+    },
+    {
+      "id": "processing_options",
+      "name": "Processing Options",
+      "members": [
+        "merge_2d",
+        "crop_3d",
+        "philips_scaling",
+        "scaling",
+        "ignore_derived"
+      ],
+      "description": "Options affecting how DICOM data is processed"
+    },
+    {
+      "id": "execution_options",
+      "name": "Execution Options",
+      "members": [
+        "verbose",
+        "search_mode",
+        "depth",
+        "single_file",
+        "rename",
+        "conflict_behavior"
+      ],
+      "description": "Options controlling program execution behavior"
+    }
+  ]
+}

--- a/descriptors/dcm2niix/dcm2niix.json
+++ b/descriptors/dcm2niix/dcm2niix.json
@@ -33,10 +33,7 @@
       "value-key": "[ADJACENT]",
       "command-line-flag": "-a",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Adjacent DICOMs (images from same series always in same folder) for faster conversion"
     },
     {
@@ -46,11 +43,7 @@
       "value-key": "[BIDS]",
       "command-line-flag": "-b",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "o"
-      ],
+      "value-choices": ["y", "n", "o"],
       "description": "Generate BIDS sidecar JSON files (o=only: no NIfTI)"
     },
     {
@@ -60,10 +53,7 @@
       "value-key": "[BIDS_ANON]",
       "command-line-flag": "-ba",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Anonymize BIDS sidecar files by removing personal information"
     },
     {
@@ -93,13 +83,7 @@
       "value-key": "[EXPORT_FORMAT]",
       "command-line-flag": "-e",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "o",
-        "j",
-        "b"
-      ],
+      "value-choices": ["y", "n", "o", "j", "b"],
       "description": "Export format: NRRD (y), MGH (o), JSON/JNIfTI (j), or BJNIfTI (b)"
     },
     {
@@ -118,12 +102,7 @@
       "value-key": "[DEFAULTS]",
       "command-line-flag": "-g",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "o",
-        "i"
-      ],
+      "value-choices": ["y", "n", "o", "i"],
       "description": "Generate defaults file (o=only: reset and write defaults; i=ignore: reset defaults)"
     },
     {
@@ -133,10 +112,7 @@
       "value-key": "[IGNORE_DERIVED]",
       "command-line-flag": "-i",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Ignore derived, localizer and 2D images"
     },
     {
@@ -146,11 +122,7 @@
       "value-key": "[SCALING]",
       "command-line-flag": "-l",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "o"
-      ],
+      "value-choices": ["y", "n", "o"],
       "description": "Losslessly scale 16-bit integers (y=scale, n=no but uint16->int16, o=original)"
     },
     {
@@ -160,13 +132,7 @@
       "value-key": "[MERGE_2D]",
       "command-line-flag": "-m",
       "optional": true,
-      "value-choices": [
-        "n",
-        "y",
-        "0",
-        "1",
-        "2"
-      ],
+      "value-choices": ["n", "y", "0", "1", "2"],
       "description": "Merge 2D slices from same series regardless of echo, exposure, etc. (0=no, 1=yes, 2=auto)"
     },
     {
@@ -195,10 +161,7 @@
       "value-key": "[PHILIPS_SCALING]",
       "command-line-flag": "-p",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Use Philips precise float (not display) scaling"
     },
     {
@@ -208,11 +171,7 @@
       "value-key": "[SEARCH_MODE]",
       "command-line-flag": "-q",
       "optional": true,
-      "value-choices": [
-        "y",
-        "l",
-        "n"
-      ],
+      "value-choices": ["y", "l", "n"],
       "description": "Search mode (y=show number of DICOMs, l=list DICOMs, n=no)"
     },
     {
@@ -222,10 +181,7 @@
       "value-key": "[RENAME]",
       "command-line-flag": "-r",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Rename instead of convert DICOMs"
     },
     {
@@ -235,10 +191,7 @@
       "value-key": "[SINGLE_FILE]",
       "command-line-flag": "-s",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Single file mode, do not convert other images in folder"
     },
     {
@@ -257,11 +210,7 @@
       "value-key": "[VERBOSE]",
       "command-line-flag": "-v",
       "optional": true,
-      "value-choices": [
-        "0",
-        "1",
-        "2"
-      ],
+      "value-choices": ["0", "1", "2"],
       "description": "Verbose output (0=no, 1=yes, 2=logorrheic)"
     },
     {
@@ -271,11 +220,7 @@
       "value-key": "[CONFLICT_BEHAVIOR]",
       "command-line-flag": "-w",
       "optional": true,
-      "value-choices": [
-        0,
-        1,
-        2
-      ],
+      "value-choices": [0, 1, 2],
       "description": "Write behavior for name conflicts (0=skip, 1=overwrite, 2=add suffix)"
     },
     {
@@ -285,11 +230,7 @@
       "value-key": "[CROP_3D]",
       "command-line-flag": "-x",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "i"
-      ],
+      "value-choices": ["y", "n", "i"],
       "description": "Crop 3D acquisitions (i=ignore: neither crop nor rotate)"
     },
     {
@@ -299,13 +240,7 @@
       "value-key": "[GZ_COMPRESS]",
       "command-line-flag": "-z",
       "optional": true,
-      "value-choices": [
-        "y",
-        "o",
-        "i",
-        "n",
-        "3"
-      ],
+      "value-choices": ["y", "o", "i", "n", "3"],
       "description": "gz compress images (y=pigz, o=optimal pigz, i=internal:zlib, n=no, 3=no,3D)"
     },
     {
@@ -315,11 +250,7 @@
       "value-key": "[ENDIAN]",
       "command-line-flag": "--big-endian",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n",
-        "o"
-      ],
+      "value-choices": ["y", "n", "o"],
       "description": "Byte order (y=big-end, n=little-end, o=optimal/native)"
     },
     {
@@ -329,10 +260,7 @@
       "value-key": "[PROGRESS]",
       "command-line-flag": "--progress",
       "optional": true,
-      "value-choices": [
-        "y",
-        "n"
-      ],
+      "value-choices": ["y", "n"],
       "description": "Slicer format progress information"
     },
     {
@@ -380,10 +308,7 @@
     {
       "id": "bids_options",
       "name": "BIDS Options",
-      "members": [
-        "bids",
-        "bids_anon"
-      ],
+      "members": ["bids", "bids_anon"],
       "description": "Options related to BIDS sidecar generation"
     },
     {

--- a/packages/dcm2niix.json
+++ b/packages/dcm2niix.json
@@ -1,0 +1,21 @@
+{
+    "id": "dcm2niix",
+    "name": "dcm2niix",
+    "url": "https://github.com/rordenlab/dcm2niix",
+    "author": "Chris Rorden",
+    "approach": "Manual",
+    "status": "Experimental",
+    "container": "vnmd/dcm2niix_v1.0.20240202:20241125",
+    "version": "1.0.20240202",
+    "description": "Chris Rorden's dcm2niiX - DICOM to NIfTI converter. Converts DICOM files to NIfTI format with optional BIDS sidecar generation.",
+    "api": {
+      "endpoints": [
+        {
+          "target": "dcm2niix",
+          "status": "done",
+          "descriptor": "descriptors/dcm2niix/dcm2niix.json"
+        }
+      ]
+    }
+  }
+  


### PR DESCRIPTION
```sh
[D] Running command: dcm2niix -o . '/styx_input/0/New folder'
[E] Unable to find image 'vnmd/dcm2niix_v1.0.20240202:20241125' locally
[E] 20241125: Pulling from vnmd/dcm2niix_v1.0.20240202
[E] Digest: sha256:5fe31fb81519fc67808dc910841ca872bec9b47d5403eeacb97a10373ef81c0e
[E] Status: Downloaded newer image for vnmd/dcm2niix_v1.0.20240202:20241125
[I] Chris Rorden's dcm2niiX version v1.0.20240202  (JP2:OpenJPEG) (JP-LS:CharLS) GCC8.4.0 x86-64 (64-bit Linux)
[I] Found 1 DICOM file(s)
[I] Convert 1 DICOM as ./New_folder_EPI_PE=AP_20180918121230_3 (72x72x5x1)
[I] Conversion required 0.021319 seconds (0.004271 for core code).
[I] Executed dcm2niix in 0:00:01.198946
Dcm2niixOutputs(root=WindowsPath('styx_tmp/6f88e88407e2bd80_0_dcm2niix'))
```

Tested very roughly.