### PR TITLE
fslmerge

### DIFF
--- a/descriptors/fsl/fslmerge.json
+++ b/descriptors/fsl/fslmerge.json
@@ -4,7 +4,7 @@
   "author": "FMRIB Analysis Group, University of Oxford",
   "description": "FSL tool to concatenate images in various dimensions",
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki",
-  "command-line": "fslmerge [MERGE_SET_TR] [OUTPUT_FILE] [INPUT_FILES] [TR_VALUE]",
+  "command-line": "fslmerge [MERGE_TIME] [MERGE_SET_TR] [OUTPUT_FILE] [INPUT_FILES] [TR_VALUE]",
   "container-image": {
     "type": "docker",
     "image": "brainlife/fsl:6.0.4-patched2"
@@ -118,10 +118,10 @@
   ],
   "output-files": [
     {
-      "path-template": "[OUTPUT_FILE].nii.gz",
+      "path-template": "[OUTPUT_FILE]",
       "description": "Output concatenated image file",
       "optional": false,
-      "id": "outfile",
+      "id": "out_file",
       "name": "Output File"
     }
   ]


### PR DESCRIPTION
Tested using
```
def fsl_fslmerge(input_files: list):
    """
    fslmerge -t vol0000_trans_merged.nii.gz 
    ../applyxfm_derivfunc_to_standard_189_/mapflow/_applyxfm_derivfunc_to_standard_189_1/vol0001_trans.nii.gz 
    ../applyxfm_derivfunc_to_standard_189_/mapflow/_applyxfm_derivfunc_to_standard_189_2/vol0002_trans.nii.gz
    """
    out = fsl.fslmerge(merge_time = True, output_file="desc-merged.nii.gz", input_files=input_files)
    return out 
```