### PR TITLE
Update the argument type of outputs

### DIFF
--- a/descriptors/afni/SurfSmooth.json
+++ b/descriptors/afni/SurfSmooth.json
@@ -62,7 +62,7 @@
     {
       "id": "output_file",
       "name": "Output File",
-      "type": "File",
+      "type": "String",
       "description": "Name of output file. Default based on method being used.",
       "command-line-flag": "-output",
       "optional": true,

--- a/descriptors/afni/apsearch.json
+++ b/descriptors/afni/apsearch.json
@@ -22,7 +22,7 @@
     {
       "description": "File to save the search results",
       "value-key": "[FILE_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "file_output",
       "name": "File Output"

--- a/descriptors/afni/imand.json
+++ b/descriptors/afni/imand.json
@@ -31,7 +31,7 @@
     {
       "description": "Output image file.",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_image",
       "name": "Output Image"

--- a/descriptors/afni/imrotate.json
+++ b/descriptors/afni/imrotate.json
@@ -22,7 +22,7 @@
     {
       "description": "Output image file",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_image",
       "name": "Output Image"

--- a/descriptors/afni/qhull.json
+++ b/descriptors/afni/qhull.json
@@ -193,7 +193,7 @@
       "command-line-flag": "TO",
       "description": "Output results to file.",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output File"

--- a/descriptors/afni/quotize.json
+++ b/descriptors/afni/quotize.json
@@ -24,7 +24,7 @@
     {
       "description": "Output file which will contain the C array of strings.",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_file",
       "name": "Output file"

--- a/descriptors/ants/AddNoiseToImage.json
+++ b/descriptors/ants/AddNoiseToImage.json
@@ -18,7 +18,11 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [2, 3, 4],
+      "value-choices": [
+        2,
+        3,
+        4
+      ],
       "command-line-flag": "--image-dimensionality",
       "description": "This option forces the image to be treated as a specified-dimensional image. If not specified, the program tries to infer the dimensionality from the input image."
     },
@@ -38,14 +42,19 @@
       "type": "String",
       "optional": false,
       "command-line-flag": "--noise-model",
-      "value-choices": ["AdditiveGaussian", "SaltAndPepper", "Shot", "Speckle"],
+      "value-choices": [
+        "AdditiveGaussian",
+        "SaltAndPepper",
+        "Shot",
+        "Speckle"
+      ],
       "description": "Use different noise models each with its own (default) parameters."
     },
     {
       "id": "output",
       "name": "Output",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "command-line-flag": "--output",
       "description": "The output consists of the noise corrupted version of the input image."
@@ -57,7 +66,10 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "command-line-flag": "--verbose",
       "description": "Verbose output."
     }

--- a/descriptors/ants/ConvertScalarImageToRGB.json
+++ b/descriptors/ants/ConvertScalarImageToRGB.json
@@ -32,7 +32,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output RGB image file."
     },

--- a/descriptors/ants/CreateDisplacementField.json
+++ b/descriptors/ants/CreateDisplacementField.json
@@ -27,7 +27,10 @@
       "type": "Number",
       "integer": true,
       "optional": false,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "description": "Create zero-valued vectors along the borders when enabled (pass 1), recommended for better displacement field behavior."
     },
     {
@@ -45,7 +48,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output displacement field image with itkVector pixels."
     }

--- a/descriptors/ants/CreateTiledMosaic.json
+++ b/descriptors/ants/CreateTiledMosaic.json
@@ -60,7 +60,7 @@
       "id": "output",
       "name": "Output Tiled Mosaic Image",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "command-line-flag": "-o",
       "description": "The output is the tiled mosaic image. The format must support the specific data type: floating point images without RGB overlays, Rgb images with intensities scaled to [0,255] if overlays are present."
@@ -82,7 +82,14 @@
       "optional": true,
       "command-line-flag": "-d",
       "description": "Specifies the direction of the slices. Can be based on image storage in memory or aligned physical space. Defaults to z-direction if unspecified.",
-      "value-choices": ["0", "1", "2", "x", "y", "z"]
+      "value-choices": [
+        "0",
+        "1",
+        "2",
+        "x",
+        "y",
+        "z"
+      ]
     },
     {
       "id": "pad_or_crop",
@@ -119,7 +126,10 @@
       "integer": true,
       "optional": true,
       "command-line-flag": "-g",
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "description": "Permute (or swap) the axes of the individual slice images."
     }
   ],

--- a/descriptors/ants/ImageMath.json
+++ b/descriptors/ants/ImageMath.json
@@ -18,7 +18,11 @@
       "type": "Number",
       "integer": true,
       "optional": false,
-      "value-choices": [2, 3, 4],
+      "value-choices": [
+        2,
+        3,
+        4
+      ],
       "description": "The dimensionality of the image. Use 2 or 3 for spatial images, and 4 for 4D images like time-series data."
     },
     {
@@ -33,7 +37,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output image file resulting from the operations."
     },

--- a/descriptors/ants/MultiplyImages.json
+++ b/descriptors/ants/MultiplyImages.json
@@ -19,7 +19,10 @@
       "description": "3 or 2. Image dimension (2 or 3).",
       "optional": false,
       "integer": true,
-      "value-choices": [3, 2]
+      "value-choices": [
+        3,
+        2
+      ]
     },
     {
       "id": "first_input",
@@ -42,7 +45,7 @@
     {
       "id": "output_product_image",
       "name": "Output product image",
-      "type": "File",
+      "type": "String",
       "value-key": "[OUTPUT_PRODUCT_IMAGE]",
       "description": "Outputfname.nii.gz: the name of the resulting image.",
       "optional": false
@@ -77,7 +80,10 @@
     {
       "id": "second_input_group",
       "name": "Second input group",
-      "members": ["second_input", "second_input_2"],
+      "members": [
+        "second_input",
+        "second_input_2"
+      ],
       "mutually-exclusive": true
     }
   ]

--- a/descriptors/ants/NonLocalSuperResolution.json
+++ b/descriptors/ants/NonLocalSuperResolution.json
@@ -14,7 +14,11 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [2, 3, 4],
+      "value-choices": [
+        2,
+        3,
+        4
+      ],
       "description": "This option forces the image to be treated as a specified-dimensional image. If not specified, the program tries to infer the dimensionality from the input image."
     },
     {
@@ -51,7 +55,10 @@
       "value-key": "[PATCH_RADIUS]",
       "type": "String",
       "optional": true,
-      "value-choices": ["1", "1x1x1"],
+      "value-choices": [
+        "1",
+        "1x1x1"
+      ],
       "description": "Patch radius. Default = 1x1x1."
     },
     {
@@ -61,7 +68,10 @@
       "value-key": "[SEARCH_RADIUS]",
       "type": "String",
       "optional": true,
-      "value-choices": ["3", "3x3x3"],
+      "value-choices": [
+        "3",
+        "3x3x3"
+      ],
       "description": "Search radius. Default = 3x3x3."
     },
     {
@@ -118,7 +128,7 @@
       "name": "Output",
       "command-line-flag": "-o",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output consists of the noise corrected version of the input image. Optionally, one can also output the estimated noise image."
     },
@@ -130,7 +140,10 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "description": "Verbose output."
     }
   ],

--- a/descriptors/ants/PasteImageIntoImage.json
+++ b/descriptors/ants/PasteImageIntoImage.json
@@ -31,7 +31,7 @@
       "id": "output_image",
       "name": "Output image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "description": "The resulting image after pasting."
     },
     {
@@ -59,7 +59,11 @@
       "integer": true,
       "optional": true,
       "default-value": 0,
-      "value-choices": [0, 1, 2],
+      "value-choices": [
+        0,
+        1,
+        2
+      ],
       "description": "Defines behavior when the input image voxel is non-background and the corresponding canvas voxel is background: 0 - leave as is, 1 - replace with input voxel value, 2 - replace with conflict label."
     },
     {

--- a/descriptors/ants/ResampleImage.json
+++ b/descriptors/ants/ResampleImage.json
@@ -26,7 +26,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "description": "The output image file after resampling."
     },
     {
@@ -42,7 +42,13 @@
       "value-key": "[INTERPOLATE_TYPE]",
       "type": "String",
       "optional": true,
-      "value-choices": ["0", "1", "2", "3", "4"],
+      "value-choices": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4"
+      ],
       "description": "Specifies the interpolation type. 0: linear (default), 1: nearest-neighbor, 2: gaussian, 3: windowedSinc, 4: B-Spline."
     },
     {
@@ -51,7 +57,16 @@
       "value-key": "[PIXELTYPE]",
       "type": "String",
       "optional": true,
-      "value-choices": ["0", "1", "2", "3", "4", "5", "6", "7"],
+      "value-choices": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7"
+      ],
       "description": "Specifies the pixel type of the output image. 0: char, 1: unsigned char, 2: short, 3: unsigned short, 4: int, 5: unsigned int, 6: float (default), 7: double."
     }
   ],

--- a/descriptors/ants/SetSpacing.json
+++ b/descriptors/ants/SetSpacing.json
@@ -24,7 +24,7 @@
       "id": "output_file",
       "name": "Output file",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "description": "The output image file in NII format."
     },
     {

--- a/descriptors/ants/SimulateDisplacementField.json
+++ b/descriptors/ants/SimulateDisplacementField.json
@@ -18,7 +18,10 @@
       "name": "Displacement Field Type",
       "value-key": "[DISPLACEMENT_FIELD_TYPE]",
       "type": "String",
-      "value-choices": ["BSpline", "Exponential"],
+      "value-choices": [
+        "BSpline",
+        "Exponential"
+      ],
       "description": "Type of displacement field to simulate."
     },
     {
@@ -32,7 +35,7 @@
       "id": "output_field",
       "name": "Output Field",
       "value-key": "[OUTPUT_FIELD]",
-      "type": "File",
+      "type": "String",
       "description": "Path to save the output displacement field."
     },
     {

--- a/descriptors/ants/SmoothDisplacementField.json
+++ b/descriptors/ants/SmoothDisplacementField.json
@@ -31,7 +31,7 @@
       "id": "output_field",
       "name": "Output Field",
       "value-key": "[OUTPUT_FIELD]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output file for the smoothed displacement field."
     },
@@ -70,7 +70,10 @@
       "type": "Number",
       "integer": true,
       "default-value": 0,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "optional": true,
       "description": "Estimate the inverse of the displacement field if set to 1."
     },

--- a/descriptors/ants/SuperResolution.json
+++ b/descriptors/ants/SuperResolution.json
@@ -17,7 +17,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The file path for the output super-resolved image."
     },

--- a/descriptors/ants/SurfaceCurvature.json
+++ b/descriptors/ants/SurfaceCurvature.json
@@ -20,7 +20,7 @@
       "id": "filename_out",
       "name": "Output Image",
       "value-key": "[FILENAME_OUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output image file in .nii format.",
       "command-line-flag": ""
@@ -40,7 +40,12 @@
       "value-key": "[OPTION]",
       "type": "Number",
       "optional": false,
-      "value-choices": [0, 5, 6, 7],
+      "value-choices": [
+        0,
+        5,
+        6,
+        7
+      ],
       "description": "The operation mode: 0 for mean curvature, 5 for surface characterization, 6 for Gaussian curvature, and 7 for surface area.",
       "command-line-flag": ""
     }

--- a/descriptors/ants/ThresholdImage.json
+++ b/descriptors/ants/ThresholdImage.json
@@ -27,7 +27,7 @@
       "id": "out_image",
       "name": "Output Image",
       "value-key": "[OUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output image file after thresholding."
     },

--- a/descriptors/ants/TileImages.json
+++ b/descriptors/ants/TileImages.json
@@ -17,7 +17,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "description": "The path for the output tiled image."
     },
     {

--- a/descriptors/ants/TimeSCCAN.json
+++ b/descriptors/ants/TimeSCCAN.json
@@ -16,7 +16,7 @@
       "name": "Output Image",
       "value-key": "[OUTPUT]",
       "command-line-flag": "--output",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "Output is a 2D correlation matrix."
     },
@@ -124,7 +124,12 @@
       "command-line-flag": "--partial-scca-option",
       "type": "String",
       "optional": true,
-      "value-choices": ["PQ", "PminusRQ", "PQminusR", "PminusRQminusR"],
+      "value-choices": [
+        "PQ",
+        "PminusRQ",
+        "PQminusR",
+        "PminusRQminusR"
+      ],
       "description": "Choices for partial SCCA: PQ, PminusRQ, PQminusR, PminusRQminusR."
     },
     {

--- a/descriptors/ants/WarpTimeSeriesImageMultiTransform.json
+++ b/descriptors/ants/WarpTimeSeriesImageMultiTransform.json
@@ -13,7 +13,10 @@
       "type": "Number",
       "integer": true,
       "optional": false,
-      "value-choices": [3, 4],
+      "value-choices": [
+        3,
+        4
+      ],
       "description": "The dimensionality of the input images (3D or 4D)."
     },
     {
@@ -28,7 +31,7 @@
       "id": "output_image",
       "name": "Output Image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "description": "The output image after transformation. It is resampled based on the reference image domain."
     },
@@ -56,7 +59,10 @@
       "value-key": "[INTERPOLATION]",
       "type": "String",
       "optional": true,
-      "value-choices": ["NearestNeighbor", "BSpline"],
+      "value-choices": [
+        "NearestNeighbor",
+        "BSpline"
+      ],
       "description": "Specifies the type of interpolation to use: Nearest Neighbor or 3rd order B-Spline."
     }
   ],

--- a/descriptors/ants/antsAlignOrigin.json
+++ b/descriptors/ants/antsAlignOrigin.json
@@ -12,7 +12,10 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [2, 3],
+      "value-choices": [
+        2,
+        3
+      ],
       "command-line-flag": "--dimensionality",
       "description": "This option forces the image to be treated as a specified-dimensional image. If not specified, antsWarp tries to infer the dimensionality from the input image."
     },
@@ -38,7 +41,7 @@
       "id": "output",
       "name": "Output",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "command-line-flag": "--output",
       "description": "One can either output the warped image or, if the boolean is set, one can print out the displacement field based on the composite transform and the reference image."

--- a/descriptors/ants/antsLandmarkBasedTransformInitializer.json
+++ b/descriptors/ants/antsLandmarkBasedTransformInitializer.json
@@ -42,14 +42,18 @@
       "value-key": "[TRANSFORM_TYPE]",
       "type": "String",
       "description": "The type of transform to initialize. Options are 'rigid', 'affine', or 'bspline'.",
-      "value-choices": ["rigid", "affine", "bspline"],
+      "value-choices": [
+        "rigid",
+        "affine",
+        "bspline"
+      ],
       "optional": false
     },
     {
       "id": "output_transform",
       "name": "Output Transform",
       "value-key": "[OUTPUT_TRANSFORM]",
-      "type": "File",
+      "type": "String",
       "description": "The output transform file that will be created.",
       "optional": false
     },
@@ -86,7 +90,10 @@
       "type": "Number",
       "integer": true,
       "description": "Enforces stationary boundaries for the B-spline transform. Default is 1 (true).",
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "optional": true
     },
     {

--- a/descriptors/ants/antsMotionCorrStats.json
+++ b/descriptors/ants/antsMotionCorrStats.json
@@ -33,7 +33,7 @@
       "id": "output",
       "name": "Output file",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "command-line-flag": "-o",
       "description": "Specify the output file."
@@ -55,7 +55,10 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "command-line-flag": "-f",
       "description": "Do framewise summary stats."
     },
@@ -84,7 +87,10 @@
       "type": "Number",
       "integer": true,
       "optional": true,
-      "value-choices": [0, 1],
+      "value-choices": [
+        0,
+        1
+      ],
       "command-line-flag": "--help",
       "description": "Print the help menu. Short version with -h."
     }

--- a/descriptors/freesurfer/AntsN4BiasFieldCorrectionFs.json
+++ b/descriptors/freesurfer/AntsN4BiasFieldCorrectionFs.json
@@ -21,7 +21,7 @@
       "id": "output_file",
       "name": "Output File",
       "optional": false,
-      "type": "File",
+      "type": "String",
       "value-key": "[OUTPUT_FILE]"
     },
     {

--- a/descriptors/freesurfer/createMorph.json
+++ b/descriptors/freesurfer/createMorph.json
@@ -18,7 +18,7 @@
     {
       "id": "output_transform",
       "name": "Output Transform",
-      "type": "File",
+      "type": "String",
       "value-key": "[OUTPUT_TRANSFORM]",
       "command-line-flag": "--out",
       "description": "Output transform file in tm3d format.",

--- a/descriptors/freesurfer/defect2seg.json
+++ b/descriptors/freesurfer/defect2seg.json
@@ -11,7 +11,7 @@
       "command-line-flag": "--o",
       "description": "Output segmentation volume",
       "value-key": "[OUTPUT_SEG]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_seg",
       "name": "Output Segmentation"

--- a/descriptors/freesurfer/dmri_spline.json
+++ b/descriptors/freesurfer/dmri_spline.json
@@ -28,7 +28,7 @@
       "command-line-flag": "--out",
       "description": "Output volume of the interpolated spline",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_volume",
       "name": "Output Volume"
@@ -46,7 +46,7 @@
       "command-line-flag": "--outpts",
       "description": "Output text file containing all interpolated spline points",
       "value-key": "[OUTPUT_POINTS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_points",
       "name": "Output Points File"

--- a/descriptors/freesurfer/exportGcam.json
+++ b/descriptors/freesurfer/exportGcam.json
@@ -36,7 +36,7 @@
       "command-line-flag": "--out_gcam",
       "description": "Output GCAM (Geodesic Coordinate-based Anatomic Mapping).",
       "value-key": "[OUT_GCAM]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "out_gcam",
       "name": "Output GCAM"
@@ -67,7 +67,10 @@
       "optional": true,
       "id": "interp_method",
       "name": "Interpolation Method",
-      "value-choices": ["linear", "nearest"],
+      "value-choices": [
+        "linear",
+        "nearest"
+      ],
       "default-value": "linear"
     },
     {

--- a/descriptors/freesurfer/make_upright.json
+++ b/descriptors/freesurfer/make_upright.json
@@ -17,7 +17,7 @@
     {
       "description": "Output MRI image file in .mgz format",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_image",
       "name": "Output MRI Image"

--- a/descriptors/freesurfer/mergeseg.json
+++ b/descriptors/freesurfer/mergeseg.json
@@ -27,7 +27,7 @@
       "command-line-flag": "--o",
       "description": "Output merged segmentation",
       "value-key": "[OUT_SEG]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "out_seg",
       "name": "Output Segmentation"

--- a/descriptors/freesurfer/mideface.json
+++ b/descriptors/freesurfer/mideface.json
@@ -16,7 +16,7 @@
     {
       "id": "output_volume",
       "name": "Output Volume",
-      "type": "File",
+      "type": "String",
       "description": "Defaced output volume",
       "optional": false,
       "value-key": "[OUTPUT_VOLUME]",

--- a/descriptors/freesurfer/mri_brain_volume.json
+++ b/descriptors/freesurfer/mri_brain_volume.json
@@ -14,7 +14,7 @@
     {
       "description": "Output file for brain volume",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output file"

--- a/descriptors/freesurfer/mri_brainvol_stats.json
+++ b/descriptors/freesurfer/mri_brainvol_stats.json
@@ -44,7 +44,7 @@
       "command-line-flag": "--out",
       "description": "Output file path to write the brain volume statistics.",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output File"

--- a/descriptors/freesurfer/mri_compute_volume_intensities.json
+++ b/descriptors/freesurfer/mri_compute_volume_intensities.json
@@ -25,7 +25,7 @@
     {
       "description": "Output volume file",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/freesurfer/mri_entowm_seg.json
+++ b/descriptors/freesurfer/mri_entowm_seg.json
@@ -19,7 +19,7 @@
       "command-line-flag": "-o",
       "description": "Segmentation output file or directory (required if --i is provided).",
       "value-key": "[OUTPUT_SEGMENTATION]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_segmentation",
       "name": "Output Segmentation"

--- a/descriptors/freesurfer/mri_fuse_intensity_images.json
+++ b/descriptors/freesurfer/mri_fuse_intensity_images.json
@@ -31,7 +31,7 @@
     {
       "description": "Output fused volume",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/freesurfer/mri_gca_ambiguous.json
+++ b/descriptors/freesurfer/mri_gca_ambiguous.json
@@ -15,7 +15,7 @@
     {
       "description": "The output MR image file",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output volume"

--- a/descriptors/freesurfer/mri_hausdorff_dist.json
+++ b/descriptors/freesurfer/mri_hausdorff_dist.json
@@ -25,7 +25,7 @@
     {
       "description": "Output text file",
       "value-key": "[OUTPUT_TEXT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_text_file",
       "name": "Output Text File"

--- a/descriptors/freesurfer/mri_hires_register.json
+++ b/descriptors/freesurfer/mri_hires_register.json
@@ -37,7 +37,7 @@
     {
       "description": "The output transform file",
       "value-key": "[OUTPUT_XFORM]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_xform",
       "name": "Output Transform"

--- a/descriptors/freesurfer/mri_morphology.json
+++ b/descriptors/freesurfer/mri_morphology.json
@@ -49,7 +49,7 @@
     {
       "description": "Output volume file to store the results of the operation.",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/freesurfer/mri_refine_seg.json
+++ b/descriptors/freesurfer/mri_refine_seg.json
@@ -17,7 +17,7 @@
       "command-line-flag": "-o",
       "description": "Refined segmentation output name.",
       "value-key": "[OUTPUT_SEGMENTATION]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_segmentation",
       "name": "Output Segmentation"

--- a/descriptors/freesurfer/mri_segment_thalamic_nuclei_dti_cnn.json
+++ b/descriptors/freesurfer/mri_segment_thalamic_nuclei_dti_cnn.json
@@ -43,7 +43,7 @@
     {
       "id": "output",
       "name": "Segmentation output",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "value-key": "[OUTPUT]",
       "description": "Path to the segmentation output(s) or folder.",
@@ -52,7 +52,7 @@
     {
       "id": "volume_output",
       "name": "Volume output",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "value-key": "[VOLUME_OUTPUT]",
       "description": "CSV file for volumes of all structures and subjects.",
@@ -61,7 +61,7 @@
     {
       "id": "posteriors_output",
       "name": "Posteriors output",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "value-key": "[POSTERIORS_OUTPUT]",
       "description": "Path to the posteriors output(s) or folder.",

--- a/descriptors/freesurfer/mri_synthmorph.json
+++ b/descriptors/freesurfer/mri_synthmorph.json
@@ -26,7 +26,7 @@
       "command-line-flag": "-o",
       "id": "moved_output",
       "name": "Moved Output Image",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "description": "The resulting image after registration.",
       "value-key": "[MOVED_OUTPUT]"
@@ -54,7 +54,11 @@
       "id": "transformation_model",
       "name": "Transformation Model",
       "type": "String",
-      "value-choices": ["deform", "affine", "rigid"],
+      "value-choices": [
+        "deform",
+        "affine",
+        "rigid"
+      ],
       "default-value": "deform",
       "optional": true,
       "description": "Specifies the registration transformation model. Options include 'deform', 'affine', and 'rigid'.",
@@ -102,7 +106,10 @@
       "id": "extent",
       "name": "Extent",
       "type": "Number",
-      "value-choices": [192, 256],
+      "value-choices": [
+        192,
+        256
+      ],
       "optional": true,
       "description": "Isotropic extent of the registration space in unit voxels.",
       "default-value": 256,

--- a/descriptors/freesurfer/mri_synthstrip.json
+++ b/descriptors/freesurfer/mri_synthstrip.json
@@ -19,7 +19,7 @@
       "command-line-flag": "-o",
       "description": "Save stripped image to path.",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_image",
       "name": "Output image"

--- a/descriptors/freesurfer/mri_twoclass.json
+++ b/descriptors/freesurfer/mri_twoclass.json
@@ -23,7 +23,7 @@
     {
       "description": "Output volume",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/freesurfer/mris_apply_reg.json
+++ b/descriptors/freesurfer/mris_apply_reg.json
@@ -19,7 +19,7 @@
       "command-line-flag": "--trg",
       "description": "Target output file",
       "value-key": "[TRG_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "trg_output",
       "name": "Target Output"

--- a/descriptors/freesurfer/mris_defects_pointset.json
+++ b/descriptors/freesurfer/mris_defects_pointset.json
@@ -27,7 +27,7 @@
       "description": "Output pointset file (json)",
       "id": "out",
       "name": "Output pointset file",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "value-key": "[OUT]"
     },

--- a/descriptors/freesurfer/mris_multimodal.json
+++ b/descriptors/freesurfer/mris_multimodal.json
@@ -25,7 +25,7 @@
     {
       "description": "Output surface file.",
       "value-key": "[OUTPUT_SURFACE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_surface",
       "name": "Output Surface",
@@ -62,7 +62,7 @@
       "command-line-flag": "-a",
       "description": "Output file for annotation data.",
       "value-key": "[ANNOTATION_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "annotation_output",
       "name": "Annotation Output"
@@ -71,7 +71,7 @@
       "command-line-flag": "-v",
       "description": "Output file for overlay data.",
       "value-key": "[OVERLAY_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "overlay_output",
       "name": "Overlay Output"
@@ -80,7 +80,7 @@
       "command-line-flag": "-c",
       "description": "Output CSV file.",
       "value-key": "[CSV_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "csv_output",
       "name": "CSV Output"

--- a/descriptors/freesurfer/mris_remesh.json
+++ b/descriptors/freesurfer/mris_remesh.json
@@ -18,7 +18,7 @@
       "id": "output",
       "name": "Output Surface",
       "optional": false,
-      "type": "File",
+      "type": "String",
       "command-line-flag": "-o",
       "value-key": "[OUTPUT]"
     },

--- a/descriptors/freesurfer/mris_remove_intersection.json
+++ b/descriptors/freesurfer/mris_remove_intersection.json
@@ -17,7 +17,7 @@
     {
       "description": "Corrected output surface file.",
       "value-key": "[CORRECTED_SURFACE_OUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "corrected_surface_out_file",
       "name": "Corrected Surface Out File"

--- a/descriptors/freesurfer/mris_resample.json
+++ b/descriptors/freesurfer/mris_resample.json
@@ -35,7 +35,7 @@
     {
       "id": "output",
       "name": "Output Resampled Surface",
-      "type": "File",
+      "type": "String",
       "description": "Output resampled surface.",
       "value-key": "[OUTPUT]",
       "optional": false,
@@ -54,7 +54,7 @@
       "command-line-flag": "--annot_out",
       "id": "annot_out",
       "name": "Output Annotation",
-      "type": "File",
+      "type": "String",
       "description": "Output annotation (for the resampled atlas). If present, input annotation must be present as well.",
       "value-key": "[ANNOT_OUT]",
       "optional": true

--- a/descriptors/freesurfer/mris_seg2annot.json
+++ b/descriptors/freesurfer/mris_seg2annot.json
@@ -55,7 +55,7 @@
       "command-line-flag": "--o",
       "description": "Output annotation file. E.g., lh.aparc.annot",
       "value-key": "[OUTPUT_ANNOTATION]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_annotation",
       "name": "Output annotation file"

--- a/descriptors/freesurfer/mris_simulate_atrophy.json
+++ b/descriptors/freesurfer/mris_simulate_atrophy.json
@@ -44,7 +44,7 @@
     {
       "description": "Output volume file",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/freesurfer/mris_thickness_diff.json
+++ b/descriptors/freesurfer/mris_thickness_diff.json
@@ -32,7 +32,7 @@
       "description": "Output file name",
       "value-key": "[OUT_FILE]",
       "command-line-flag": "-out",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "out_file",
       "name": "Output file"
@@ -41,7 +41,7 @@
       "description": "Output resampled thickness",
       "value-key": "[OUT_RESAMPLED]",
       "command-line-flag": "-out_resampled",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "out_resampled",
       "name": "Output resampled thickness file"

--- a/descriptors/freesurfer/sbtiv.json
+++ b/descriptors/freesurfer/sbtiv.json
@@ -17,7 +17,7 @@
       "command-line-flag": "-o",
       "description": "Intracranial stats output file.",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output File"

--- a/descriptors/freesurfer/train-gcs-atlas.json
+++ b/descriptors/freesurfer/train-gcs-atlas.json
@@ -55,7 +55,7 @@
       "command-line-flag": "--o",
       "description": "Output GCS file",
       "value-key": "[OUTPUT_GCS]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_gcs",
       "name": "Output GCS File"

--- a/descriptors/fsl/concat_bvars.json
+++ b/descriptors/fsl/concat_bvars.json
@@ -12,7 +12,7 @@
     {
       "description": "Output .bvars file",
       "value-key": "[OUTPUT_BVARS]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_bvars",
       "name": "Output BVARS file"

--- a/descriptors/fsl/connectedcomp.json
+++ b/descriptors/fsl/connectedcomp.json
@@ -16,7 +16,7 @@
     {
       "description": "Output image volume",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_volume",
       "name": "Output volume"

--- a/descriptors/fsl/distancemap.json
+++ b/descriptors/fsl/distancemap.json
@@ -24,7 +24,7 @@
       "command-line-flag": "-o",
       "description": "Output image filename",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_image",
       "name": "Output image"
@@ -107,7 +107,10 @@
     {
       "description": "Compulsory arguments for the distancemap tool",
       "id": "compulsory_arguments",
-      "members": ["input_image", "output_image"],
+      "members": [
+        "input_image",
+        "output_image"
+      ],
       "name": "Compulsory Arguments"
     },
     {

--- a/descriptors/fsl/fsl_glm.json
+++ b/descriptors/fsl/fsl_glm.json
@@ -33,7 +33,7 @@
       "command-line-flag": "-o",
       "description": "Output file name for GLM parameter estimates (GLM betas)",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output file"
@@ -105,7 +105,7 @@
       "command-line-flag": "--out_cope",
       "description": "Output file name for COPEs (either as text file or image)",
       "value-key": "[OUTPUT_COPES]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_copes",
       "name": "Output COPEs file"
@@ -114,7 +114,7 @@
       "command-line-flag": "--out_z",
       "description": "Output file name for Z-stats (either as text file or image)",
       "value-key": "[OUTPUT_ZSTATS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_zstats",
       "name": "Output Z-stats file"
@@ -123,7 +123,7 @@
       "command-line-flag": "--out_t",
       "description": "Output file name for t-stats (either as text file or image)",
       "value-key": "[OUTPUT_TSTATS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_tstats",
       "name": "Output t-stats file"
@@ -132,7 +132,7 @@
       "command-line-flag": "--out_p",
       "description": "Output file name for p-values of Z-stats (either as text file or image)",
       "value-key": "[OUTPUT_PVALS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_pvals",
       "name": "Output p-values file"
@@ -141,7 +141,7 @@
       "command-line-flag": "--out_f",
       "description": "Output file name for F-value of full model fit",
       "value-key": "[OUTPUT_FVALS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_fvals",
       "name": "Output F-value file"
@@ -150,7 +150,7 @@
       "command-line-flag": "--out_pf",
       "description": "Output file name for p-value for full model fit",
       "value-key": "[OUTPUT_PFVALS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_pfvals",
       "name": "Output p-value file"
@@ -159,7 +159,7 @@
       "command-line-flag": "--out_res",
       "description": "Output file name for residuals",
       "value-key": "[OUTPUT_RESIDUALS]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_residuals",
       "name": "Output residuals file"
@@ -168,7 +168,7 @@
       "command-line-flag": "--out_varcb",
       "description": "Output file name for variance of COPEs",
       "value-key": "[OUTPUT_VARCB]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_varcb",
       "name": "Output variance of COPEs file"
@@ -177,7 +177,7 @@
       "command-line-flag": "--out_sigsq",
       "description": "Output file name for residual noise variance sigma-square",
       "value-key": "[OUTPUT_SIGSQ]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_sigsq",
       "name": "Output sigma-square variance file"
@@ -186,7 +186,7 @@
       "command-line-flag": "--out_data",
       "description": "Output file name for pre-processed data",
       "value-key": "[OUTPUT_DATA]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_data",
       "name": "Output pre-processed data"
@@ -195,7 +195,7 @@
       "command-line-flag": "--out_vnscales",
       "description": "Output file name for scaling factors for variance normalisation",
       "value-key": "[OUTPUT_VNSCALES]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_vnscales",
       "name": "Output variance normalisation scales file"
@@ -235,7 +235,10 @@
     {
       "description": "Compulsory inputs for FSL GLM",
       "id": "compulsory_group",
-      "members": ["input_file", "design_matrix"],
+      "members": [
+        "input_file",
+        "design_matrix"
+      ],
       "name": "Compulsory Parameters"
     },
     {
@@ -274,13 +277,18 @@
     {
       "description": "Beta options for FSL GLM",
       "id": "beta_options_group",
-      "members": ["vx_text", "vx_images"],
+      "members": [
+        "vx_text",
+        "vx_images"
+      ],
       "name": "Beta Options"
     },
     {
       "description": "Miscellaneous options for FSL GLM",
       "id": "miscellaneous_params_group",
-      "members": ["help_flag"],
+      "members": [
+        "help_flag"
+      ],
       "name": "Miscellaneous Parameters"
     }
   ],

--- a/descriptors/fsl/fsl_mvlm.json
+++ b/descriptors/fsl/fsl_mvlm.json
@@ -114,7 +114,7 @@
       "command-line-flag": "--out_data",
       "description": "Output file name for pre-processed data",
       "value-key": "[OUT_DATA]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "out_data",
       "name": "Output data file"
@@ -123,7 +123,7 @@
       "command-line-flag": "--out_vnscales",
       "description": "Output file name for scaling factors for variance normalisation",
       "value-key": "[OUT_VNSCALES]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "out_vnscales",
       "name": "Variance normalisation scales file"
@@ -134,7 +134,10 @@
     {
       "description": "Compulsory arguments group",
       "id": "compulsory_arguments_group",
-      "members": ["input_file", "basename_output_files"],
+      "members": [
+        "input_file",
+        "basename_output_files"
+      ],
       "name": "Compulsory arguments"
     },
     {

--- a/descriptors/fsl/fsladd.json
+++ b/descriptors/fsl/fsladd.json
@@ -13,7 +13,7 @@
     {
       "description": "Output volume file",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_file",
       "name": "Output file"

--- a/descriptors/fsl/fslcomplex.json
+++ b/descriptors/fsl/fslcomplex.json
@@ -21,7 +21,7 @@
     {
       "description": "Output volume (e.g. absvol.nii.gz)",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_file",
       "name": "Output file"
@@ -69,13 +69,20 @@
     {
       "description": "Specify the specific operation for FSL Complex",
       "id": "operations_group",
-      "members": ["input_file", "output_file", "output_type"],
+      "members": [
+        "input_file",
+        "output_file",
+        "output_type"
+      ],
       "name": "Main Operations Parameters"
     },
     {
       "description": "Optional parameters",
       "id": "optional_params_group",
-      "members": ["start_vol", "end_vol"],
+      "members": [
+        "start_vol",
+        "end_vol"
+      ],
       "name": "Optional Parameters"
     }
   ],

--- a/descriptors/fsl/fslfft.json
+++ b/descriptors/fsl/fslfft.json
@@ -21,7 +21,7 @@
     {
       "description": "Output volume file (e.g. outvol.nii.gz)",
       "value-key": "[OUTPUT_VOLUME]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_volume",
       "name": "Output Volume"

--- a/descriptors/fsl/fslswapdim_exe.json
+++ b/descriptors/fsl/fslswapdim_exe.json
@@ -44,7 +44,7 @@
     {
       "description": "Output image file (optional, cannot be used with --checkLR flag)",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output File"

--- a/descriptors/fsl/ftoz.json
+++ b/descriptors/fsl/ftoz.json
@@ -39,7 +39,7 @@
       "name": "Output file",
       "description": "Output file for Z-scores",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "default-value": "zstats"
     },

--- a/descriptors/fsl/make_bianca_mask.json
+++ b/descriptors/fsl/make_bianca_mask.json
@@ -19,7 +19,7 @@
     {
       "description": "Output image",
       "value-key": "[OUTPUT_IMAGE]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_image",
       "name": "Output Image"
@@ -248,7 +248,10 @@
     {
       "description": "Optional miscellaneous parameters when running make_bianca_mask",
       "id": "miscellaneous_params_group",
-      "members": ["verbose_flag", "debug_flag"],
+      "members": [
+        "verbose_flag",
+        "debug_flag"
+      ],
       "name": "Miscellaneous Parameters"
     }
   ],

--- a/descriptors/fsl/makerot.json
+++ b/descriptors/fsl/makerot.json
@@ -50,7 +50,7 @@
       "command-line-flag": "--out",
       "description": "Output filename for matrix",
       "value-key": "[OUTPUT_FILE]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "output_file",
       "name": "Output file"

--- a/descriptors/fsl/overlay.json
+++ b/descriptors/fsl/overlay.json
@@ -44,7 +44,7 @@
     {
       "id": "out_file",
       "name": "Out file",
-      "type": "File",
+      "type": "String",
       "value-key": "[OUT_FILE]",
       "description": "Combined image volume.",
       "optional": true
@@ -57,7 +57,10 @@
       "description": "'float' or 'int'. Write output with float or int.",
       "optional": true,
       "default-value": "float",
-      "value-choices": ["float", "int"]
+      "value-choices": [
+        "float",
+        "int"
+      ]
     },
     {
       "id": "output_type",
@@ -66,7 +69,12 @@
       "value-key": "[OUTPUT_TYPE]",
       "description": "'nifti' or 'nifti_pair' or 'nifti_gz' or 'nifti_pair_gz'. Fsl output type.",
       "optional": true,
-      "value-choices": ["NIFTI", "NIFTI_PAIR", "NIFTI_GZ", "NIFTI_PAIR_GZ"]
+      "value-choices": [
+        "NIFTI",
+        "NIFTI_PAIR",
+        "NIFTI_GZ",
+        "NIFTI_PAIR_GZ"
+      ]
     },
     {
       "id": "stat_image",
@@ -129,13 +137,19 @@
     {
       "id": "mutex_group",
       "name": "Mutex group",
-      "members": ["bg_thresh", "full_bg_range", "auto_thresh_bg"],
+      "members": [
+        "bg_thresh",
+        "full_bg_range",
+        "auto_thresh_bg"
+      ],
       "mutually-exclusive": true
     },
     {
       "id": "mutex_group_2",
       "name": "Mutex group 2",
-      "members": ["stat_image2"],
+      "members": [
+        "stat_image2"
+      ],
       "mutually-exclusive": true
     }
   ],

--- a/descriptors/fsl/pointflirt.json
+++ b/descriptors/fsl/pointflirt.json
@@ -32,7 +32,7 @@
       "command-line-flag": "-o",
       "description": "Filename of affine matrix output",
       "value-key": "[OUT_MATRIX]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "out_matrix",
       "name": "Output matrix"

--- a/descriptors/fsl/possum_sum.json
+++ b/descriptors/fsl/possum_sum.json
@@ -22,7 +22,7 @@
       "command-line-flag": "-o",
       "description": "Output signal: sum of all the processors (possum matrix form)",
       "value-key": "[OUTPUT_SIGNAL]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_signal",
       "name": "Output signal"

--- a/descriptors/fsl/prelude.json
+++ b/descriptors/fsl/prelude.json
@@ -15,7 +15,7 @@
       "command-line-flag": "-o",
       "description": "Filename for saving the unwrapped phase output",
       "value-key": "[OUTPUT_UNWRAP]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_unwrap",
       "name": "Output unwrap file"
@@ -287,7 +287,10 @@
     {
       "description": "One or more compulsory arguments",
       "id": "compulsory_arguments",
-      "members": ["output_unwrap", "output_unwrap_alias"],
+      "members": [
+        "output_unwrap",
+        "output_unwrap_alias"
+      ],
       "name": "Compulsory Arguments"
     },
     {

--- a/descriptors/fsl/surf_proj.json
+++ b/descriptors/fsl/surf_proj.json
@@ -90,7 +90,7 @@
       "command-line-flag": "--surfout",
       "description": "Output surface file, not ASCII matrix (valid only for scalars)",
       "value-key": "[SURFACE_OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": true,
       "id": "surface_output",
       "name": "Surface output file"

--- a/descriptors/fsl/surfmaths.json
+++ b/descriptors/fsl/surfmaths.json
@@ -29,7 +29,7 @@
     {
       "description": "Output surface file.",
       "value-key": "[OUTPUT]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output",
       "name": "Output"

--- a/descriptors/fsl/systemnoise.json
+++ b/descriptors/fsl/systemnoise.json
@@ -24,7 +24,7 @@
       "command-line-flag": "--out",
       "description": "Output signal (possum matrix form)",
       "value-key": "[OUTPUT_SIGNAL]",
-      "type": "File",
+      "type": "String",
       "optional": false,
       "id": "output_signal",
       "name": "Output Signal"
@@ -71,13 +71,21 @@
     {
       "description": "Specify compulsory arguments",
       "id": "compulsory_args_group",
-      "members": ["input_signal", "output_signal", "noise_standard_deviation"],
+      "members": [
+        "input_signal",
+        "output_signal",
+        "noise_standard_deviation"
+      ],
       "name": "Compulsory Arguments"
     },
     {
       "description": "Optional arguments",
       "id": "optional_args_group",
-      "members": ["seed", "verbose_flag", "help_flag"],
+      "members": [
+        "seed",
+        "verbose_flag",
+        "help_flag"
+      ],
       "name": "Optional Arguments"
     }
   ],

--- a/descriptors/mrtrix/responsemean.json
+++ b/descriptors/mrtrix/responsemean.json
@@ -23,7 +23,7 @@
     {
       "id": "output_response",
       "name": "Output response function",
-      "type": "File",
+      "type": "String",
       "value-key": "[OUTPUT_RESPONSE]",
       "description": "Output mean response function",
       "optional": false

--- a/descriptors/niftyreg/reg_transform.json
+++ b/descriptors/niftyreg/reg_transform.json
@@ -28,7 +28,7 @@
     {
       "id": "cpp2def_output",
       "name": "CPP to DEF Output",
-      "type": "File",
+      "type": "String",
       "value-key": "[CPP2DEF_OUTPUT]",
       "description": "Filename of the output deformation field image (DEF).",
       "optional": true
@@ -53,7 +53,7 @@
     {
       "id": "comp1_output",
       "name": "Output for Composition 1",
-      "type": "File",
+      "type": "String",
       "value-key": "[COMP1_OUTPUT]",
       "description": "Filename of the output deformation field.",
       "optional": true
@@ -78,7 +78,7 @@
     {
       "id": "comp2_output",
       "name": "Output for Composition 2",
-      "type": "File",
+      "type": "String",
       "value-key": "[COMP2_OUTPUT]",
       "description": "Filename of the output deformation field.",
       "optional": true
@@ -103,7 +103,7 @@
     {
       "id": "comp3_output",
       "name": "Output for Composition 3",
-      "type": "File",
+      "type": "String",
       "value-key": "[COMP3_OUTPUT]",
       "description": "Filename of the output deformation field.",
       "optional": true
@@ -120,7 +120,7 @@
     {
       "id": "def2disp_output",
       "name": "DEF to DISP Output",
-      "type": "File",
+      "type": "String",
       "value-key": "[DEF2DISP_OUTPUT]",
       "description": "Filename of displacement field x'=x+T(x).",
       "optional": true
@@ -137,7 +137,7 @@
     {
       "id": "disp2def_output",
       "name": "DISP to DEF Output",
-      "type": "File",
+      "type": "String",
       "value-key": "[DISP2DEF_OUTPUT]",
       "description": "Filename of deformation field x'=T(x).",
       "optional": true
@@ -162,7 +162,7 @@
     {
       "id": "upd_sform_output",
       "name": "Update Sform Output",
-      "type": "File",
+      "type": "String",
       "value-key": "[UPD_SFORM_OUTPUT]",
       "description": "Updated image filename.",
       "optional": true
@@ -195,7 +195,7 @@
     {
       "id": "aff2def_output",
       "name": "Output for Aff2Def",
-      "type": "File",
+      "type": "String",
       "value-key": "[AFF2DEF_OUTPUT]",
       "description": "Output deformation field filename.",
       "optional": true
@@ -212,7 +212,7 @@
     {
       "id": "inv_affine_output",
       "name": "Output Affine for Inversion",
-      "type": "File",
+      "type": "String",
       "value-key": "[INV_AFFINE_OUTPUT]",
       "description": "Filename of inverted affine matrix.",
       "optional": true
@@ -237,7 +237,7 @@
     {
       "id": "comp_aff_output",
       "name": "Output Affine for Composition",
-      "type": "File",
+      "type": "String",
       "value-key": "[COMP_AFF_OUTPUT]",
       "description": "Filename of composed affine matrix result.",
       "optional": true

--- a/scripts/update_output_arg_type.py
+++ b/scripts/update_output_arg_type.py
@@ -1,0 +1,44 @@
+import glob
+import json
+import re
+
+out_regex = re.compile(r"\b(?:\w*_)?(?:output|out)(?:_\w*)?\b", re.IGNORECASE)
+
+# Path to folder with JSON descriptors
+json_files = glob.glob("descriptors/*/*.json")
+
+for json_file in json_files:
+    with open(json_file, "r") as f:
+        data = json.load(f)
+
+    changes_made = False
+
+    if "inputs" in data:
+        # Grab only the part that would match the value-key
+        outputs = (
+            [
+                re.split("\]", output["path-template"])[0] + "]"
+                for output in data["output-files"]
+            ]
+            if "output-files" in data
+            else []
+        )
+        for input_obj in data["inputs"]:
+            if "id" in input_obj and "type" in input_obj:
+                if (
+                    out_regex.search(input_obj["id"])
+                    and input_obj["type"] == "File"
+                    and input_obj["value-key"] in outputs
+                ):
+                    input_obj["type"] = "String"
+                    changes_made = True
+                    print(
+                        f"Changed type to 'String' for '{input_obj['name']}' in {json_file}"
+                    )
+            else:
+                print(f"Warning missing 'name' and / or 'type' in {json_file}")
+
+    if changes_made:
+        with open(json_file, "w") as f:
+            json.dump(data, f, indent=2)
+        print(f"Updated {json_file} output argument types.")


### PR DESCRIPTION
This PR adds a script (modelled after the existing ones) to change the types for the output variables (_input?_) from `File` to `String`.

The regex will match either "output" or "out" and any optional prefixes and suffixes. Could probably be improved slightly, but importantly, it doesn't miscapture workbench args like `outer_surface`.