### PR TITLE
Update script to fix output type recursively

### DIFF
--- a/scripts/update_output_arg_type.py
+++ b/scripts/update_output_arg_type.py
@@ -4,6 +4,44 @@ import re
 
 out_regex = re.compile(r"\b(?:\w*_)?(?:output|out)(?:_\w*)?\b", re.IGNORECASE)
 
+
+def find_fix_outputs(data: dict[str, str], json_file: str) -> bool:
+    if "inputs" not in data:
+        return False
+
+    outputs = {
+        re.split(r"\]", output["path-template"])[0] + "]"
+        for output in data.get("output-files", [])
+    }
+
+    changes_made = False
+    for input_obj in data["inputs"]:
+        if not all(key in input_obj for key in ("id", "type")):
+            print(f"Warning: missing 'name' and / or 'type' in {json_file}")
+            continue
+
+        if (
+            out_regex.search(input_obj["id"])
+            and input_obj["type"] == "File"
+            and input_obj["value-key"] in outputs
+        ):
+            input_obj["type"] = "String"
+            changes_made = True
+            print(f"Changed type to 'String' for {input_obj['name']} in {json_file}")
+
+        # Check nested structures recursively
+        if isinstance(input_obj["type"], dict):
+            changes_made |= find_fix_outputs(
+                data=input_obj["type"], json_file=json_file
+            )
+        elif isinstance(input_obj["type"], list):
+            for obj in input_obj["type"]:
+                if isinstance(obj, dict):
+                    changes_made |= find_fix_outputs(data=obj, json_file=json_file)
+
+    return changes_made
+
+
 # Path to folder with JSON descriptors
 json_files = glob.glob("descriptors/*/*.json")
 
@@ -11,32 +49,7 @@ for json_file in json_files:
     with open(json_file, "r") as f:
         data = json.load(f)
 
-    changes_made = False
-
-    if "inputs" in data:
-        # Grab only the part that would match the value-key
-        outputs = (
-            [
-                re.split("\]", output["path-template"])[0] + "]"
-                for output in data["output-files"]
-            ]
-            if "output-files" in data
-            else []
-        )
-        for input_obj in data["inputs"]:
-            if "id" in input_obj and "type" in input_obj:
-                if (
-                    out_regex.search(input_obj["id"])
-                    and input_obj["type"] == "File"
-                    and input_obj["value-key"] in outputs
-                ):
-                    input_obj["type"] = "String"
-                    changes_made = True
-                    print(
-                        f"Changed type to 'String' for '{input_obj['name']}' in {json_file}"
-                    )
-            else:
-                print(f"Warning missing 'name' and / or 'type' in {json_file}")
+    changes_made = find_fix_outputs(data=data, json_file=json_file)
 
     if changes_made:
         with open(json_file, "w") as f:


### PR DESCRIPTION
PR updates the script to check descriptors in a recursive manner to fix output types for sub-commands. Previously script only checked top-level of descriptor inputs.